### PR TITLE
Order kbld.k14s.io/images annotation deterministically

### DIFF
--- a/pkg/kbld/cmd/resource_with_images.go
+++ b/pkg/kbld/cmd/resource_with_images.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"sort"
+
 	"github.com/ghodss/yaml"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -15,6 +17,10 @@ type ResourceWithImages struct {
 }
 
 func NewResourceWithImages(contents map[string]interface{}, images []Image) ResourceWithImages {
+	// sort images lexicographically (by URL) to avoid unnecessary annotation changes
+	sort.Slice(images, func(i, j int) bool {
+		return images[i].URL < images[j].URL
+	})
 	return ResourceWithImages{contents, images}
 }
 


### PR DESCRIPTION
PR for #34. It sorts the images annotation by the image URL (I think the only reasonable field to sort on, since the Metas field can be nil).

The unit test is a little long in terms of loc but I think makes it easier for the reader to see how the annotation is being ordered.
