### PR TITLE
Filter and de-dupe annotations

### DIFF
--- a/pkg/kbld/cmd/image.go
+++ b/pkg/kbld/cmd/image.go
@@ -24,6 +24,30 @@ func (imgs Images) ForImage(url string) (Image, bool) {
 	return Image{}, false
 }
 
+func (i Image) Equal(other Image) bool {
+	if i.URL != other.URL {
+		return false
+	}
+	if len(i.Metas) != len(other.Metas) {
+		return false
+	}
+	for i, meta := range i.Metas {
+		if meta != other.Metas[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (imgs Images) Contains(img Image) bool {
+	for _, other := range imgs {
+		if img.Equal(other) {
+			return true
+		}
+	}
+	return false
+}
+
 // TODO only works after deserialization
 func (i Image) Description() string {
 	yamlBytes, err := yaml.Marshal(i.metasRaw)

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -141,14 +141,7 @@ func (o *ResolveOptions) updateRefsInResources(nonConfigRs []ctlres.Resource,
 			}
 
 			if o.ImagesAnnotation {
-				// if Metas is null then the image was already in digest form and we didn't need to resolve
-				// it, so the annotation isn't very useful
-				if len(img.Metas) > 0 {
-					// also check for duplicates before adding
-					if !Images(images).Contains(img) {
-						images = append(images, img)
-					}
-				}
+				images = append(images, img)
 			}
 
 			return img.URL, true

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -141,7 +141,9 @@ func (o *ResolveOptions) updateRefsInResources(nonConfigRs []ctlres.Resource,
 			}
 
 			if o.ImagesAnnotation {
-				images = append(images, img)
+				if len(img.Metas) > 0 {
+					images = append(images, img)
+				}
 			}
 
 			return img.URL, true

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -141,8 +141,13 @@ func (o *ResolveOptions) updateRefsInResources(nonConfigRs []ctlres.Resource,
 			}
 
 			if o.ImagesAnnotation {
+				// if Metas is null then the image was already in digest form and we didn't need to resolve
+				// it, so the annotation isn't very useful
 				if len(img.Metas) > 0 {
-					images = append(images, img)
+					// also check for duplicates before adding
+					if !Images(images).Contains(img) {
+						images = append(images, img)
+					}
 				}
 			}
 

--- a/test/e2e/resolve_test.go
+++ b/test/e2e/resolve_test.go
@@ -49,6 +49,7 @@ kind: Object
 spec:
 - image: nginx:1.14.2
 - image: library/nginx:1.14.2
+- image: docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 `
 
 	out, _ := kbld.RunWithOpts([]string{"-f", "-"}, RunOpts{
@@ -72,6 +73,7 @@ metadata:
           URL: library/nginx:1.14.2
         URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 spec:
+- image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 `

--- a/test/e2e/resolve_test.go
+++ b/test/e2e/resolve_test.go
@@ -44,9 +44,14 @@ func TestResolveSuccessfulWithAnnotations(t *testing.T) {
 	env := BuildEnv(t)
 	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
 
+	// The repetition in this input is so it can test for:
+	// 1) resolving
+	// 2) filtering annotations with null metas (which happens with digests, which don't get resolved)
+	// 3) de-duplicating annotations
 	input := `
 kind: Object
 spec:
+- image: nginx:1.14.2
 - image: nginx:1.14.2
 - image: library/nginx:1.14.2
 - image: docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
@@ -56,7 +61,6 @@ spec:
 		StdinReader: strings.NewReader(input),
 	})
 
-	// TODO dedup same url images
 	expectedOut := `---
 kind: Object
 metadata:
@@ -73,6 +77,7 @@ metadata:
           URL: library/nginx:1.14.2
         URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 spec:
+- image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d


### PR DESCRIPTION
This PR is a potential solution to #18. While implementing it I noticed a comment in one of the tests saying `TODO dedup same url images` which can be done at the same time, so I figured I'd attempt that too.

Note that digests already don't get _resolved_, they just get added to annotations with a null `Metas` field. So this change simply filters out those annotations (and any duplicates).

I'm creating this as a draft because:

1. I'm not sure how urgent either enhancement is, so I won't be offended if you decline one or other change (or both) – this was partly a learning exercise for me. Does it look useful?

2. If you do want it merged, I think some further unit tests for the Image.Equal and Images.Contains funcs wouldn't hurt. The updated e2e test gives some useful coverage but probably doesn't cover all cases