### PR TITLE
fix: lock file shouldn't be executable

### DIFF
--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -260,7 +260,7 @@ func (d Config) WriteToFile(path string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(path, bs, 0700)
+	err = ioutil.WriteFile(path, bs, 0600)
 	if err != nil {
 		return fmt.Errorf("Writing lock config: %s", err)
 	}


### PR DESCRIPTION
I noticed our lock files are executable, and we probably want to avoid that.