### PR TITLE
Feat/52 support additional image tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /kbld-windows-amd64.exe
 /tmp
 .DS_Store
+.vscode

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -56,7 +56,8 @@ type ImageOverride struct {
 
 type ImageDestination struct {
 	ImageRef
-	NewImage string `json:"newImage"`
+	NewImage string   `json:"newImage"`
+	Tags     []string `json:"tags"`
 }
 
 type SearchRule struct {

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -42,7 +42,6 @@ type Config struct {
 type Source struct {
 	ImageRef
 	Path string
-	Tags []string
 
 	Docker *SourceDockerOpts
 	Pack   *SourcePackOpts

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 type Source struct {
 	ImageRef
 	Path string
+	Tags []string
 
 	Docker *SourceDockerOpts
 	Pack   *SourcePackOpts

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -60,7 +60,6 @@ func (i BuiltImage) URL() (string, []ImageMeta, error) {
 			NoCache:    i.buildSource.Docker.Build.NoCache,
 			File:       i.buildSource.Docker.Build.File,
 			RawOptions: i.buildSource.Docker.Build.RawOptions,
-			Tags:       i.buildSource.Tags,
 		}
 
 		digest, err := i.docker.Build(urlRepo, i.buildSource.Path, opts)

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -14,13 +14,12 @@ type BuiltImage struct {
 	buildSource ctlconf.Source
 	docker      Docker
 	pack        Pack
-	tags        []string
 }
 
 func NewBuiltImage(url string, buildSource ctlconf.Source,
 	docker Docker, pack Pack) BuiltImage {
 
-	return BuiltImage{url, buildSource, docker, pack, buildSource.Tags}
+	return BuiltImage{url, buildSource, docker, pack}
 }
 
 func (i BuiltImage) URL() (string, []ImageMeta, error) {

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -23,10 +23,6 @@ func NewBuiltImage(url string, buildSource ctlconf.Source,
 	return BuiltImage{url, buildSource, docker, pack, buildSource.Tags}
 }
 
-func (i BuiltImage) ImageTags() []string {
-	return i.tags
-}
-
 func (i BuiltImage) URL() (string, []ImageMeta, error) {
 	sources, err := i.sources()
 	if err != nil {

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -14,12 +14,17 @@ type BuiltImage struct {
 	buildSource ctlconf.Source
 	docker      Docker
 	pack        Pack
+	tags        []string
 }
 
 func NewBuiltImage(url string, buildSource ctlconf.Source,
 	docker Docker, pack Pack) BuiltImage {
 
-	return BuiltImage{url, buildSource, docker, pack}
+	return BuiltImage{url, buildSource, docker, pack, buildSource.Tags}
+}
+
+func (i BuiltImage) ImageTags() []string {
+	return i.tags
 }
 
 func (i BuiltImage) URL() (string, []ImageMeta, error) {
@@ -59,6 +64,7 @@ func (i BuiltImage) URL() (string, []ImageMeta, error) {
 			NoCache:    i.buildSource.Docker.Build.NoCache,
 			File:       i.buildSource.Docker.Build.File,
 			RawOptions: i.buildSource.Docker.Build.RawOptions,
+			Tags:       i.buildSource.Tags,
 		}
 
 		digest, err := i.docker.Build(urlRepo, i.buildSource.Path, opts)

--- a/pkg/kbld/image/docker.go
+++ b/pkg/kbld/image/docker.go
@@ -33,7 +33,6 @@ type DockerBuildOpts struct {
 	NoCache    *bool
 	File       *string
 	RawOptions *[]string
-	Tags       []string
 }
 
 type DockerTmpRef struct {
@@ -91,11 +90,6 @@ func (d Docker) Build(image, directory string, opts DockerBuildOpts) (DockerTmpR
 		}
 		if opts.RawOptions != nil {
 			cmdArgs = append(cmdArgs, *opts.RawOptions...)
-		}
-		for _, imageTag := range opts.Tags {
-			cmdArgs = append(cmdArgs, "--tag", fmt.Sprintf(
-				"kbld:%s", imageTag),
-			)
 		}
 
 		cmdArgs = append(cmdArgs, "--tag", tmpRef.AsString(), ".")

--- a/pkg/kbld/image/docker.go
+++ b/pkg/kbld/image/docker.go
@@ -33,6 +33,7 @@ type DockerBuildOpts struct {
 	NoCache    *bool
 	File       *string
 	RawOptions *[]string
+	Tags       []string
 }
 
 type DockerTmpRef struct {
@@ -90,6 +91,11 @@ func (d Docker) Build(image, directory string, opts DockerBuildOpts) (DockerTmpR
 		}
 		if opts.RawOptions != nil {
 			cmdArgs = append(cmdArgs, *opts.RawOptions...)
+		}
+		for _, imageTag := range opts.Tags {
+			cmdArgs = append(cmdArgs, "--tag", fmt.Sprintf(
+				"kbld:%s", imageTag),
+			)
 		}
 
 		cmdArgs = append(cmdArgs, "--tag", tmpRef.AsString(), ".")
@@ -160,7 +166,7 @@ func (d Docker) RetagStable(tmpRef DockerTmpRef, image, imageID string,
 	return stableTmpRef, nil
 }
 
-func (d Docker) Push(tmpRef DockerTmpRef, imageDst string) (DockerImageDigest, error) {
+func (d Docker) Push(tmpRef DockerTmpRef, imageDst string, additionalImageTags []string) (DockerImageDigest, error) {
 	prefixedLogger := d.logger.NewPrefixedWriter(imageDst + " | ")
 
 	// Generate random tag for pushed image.
@@ -181,9 +187,19 @@ func (d Docker) Push(tmpRef DockerTmpRef, imageDst string) (DockerImageDigest, e
 		}
 	}
 
-	imageDst = imageDstTagged.Name()
+	for i, imageDstTag := range additionalImageTags {
+		imageDstTag, err := regname.NewTag(imageDst+":"+imageDstTag, regname.WeakValidation)
+		if err != nil {
+			return DockerImageDigest{}, fmt.Errorf("Generating image dst tag '%s': %s", imageDstTag, err)
+		}
+		additionalImageTags[i] = imageDstTag.Name()
+	}
 
-	prefixedLogger.Write([]byte(fmt.Sprintf("starting push (using Docker): %s -> %s\n", tmpRef.AsString(), imageDst)))
+	fullImageDst := imageDstTagged.Name()
+
+	additionalImageTags = append(additionalImageTags, fullImageDst)
+
+	prefixedLogger.Write([]byte(fmt.Sprintf("starting push (using Docker): %s -> %s\n", tmpRef.AsString(), fullImageDst)))
 	defer prefixedLogger.Write([]byte("finished push (using Docker)\n"))
 
 	prevInspectData, err := d.inspect(tmpRef.AsString())
@@ -195,32 +211,36 @@ func (d Docker) Push(tmpRef DockerTmpRef, imageDst string) (DockerImageDigest, e
 	{
 		var stdoutBuf, stderrBuf bytes.Buffer
 
-		cmd := exec.Command("docker", "tag", tmpRef.AsString(), imageDst)
-		cmd.Stdout = io.MultiWriter(&stdoutBuf, prefixedLogger)
-		cmd.Stderr = io.MultiWriter(&stderrBuf, prefixedLogger)
+		for _, imageDstTag := range additionalImageTags {
+			cmd := exec.Command("docker", "tag", tmpRef.AsString(), imageDstTag)
+			cmd.Stdout = io.MultiWriter(&stdoutBuf, prefixedLogger)
+			cmd.Stderr = io.MultiWriter(&stderrBuf, prefixedLogger)
 
-		err := cmd.Run()
-		if err != nil {
-			prefixedLogger.Write([]byte(fmt.Sprintf("tag error: %s\n", err)))
-			return DockerImageDigest{}, err
+			err := cmd.Run()
+			if err != nil {
+				prefixedLogger.Write([]byte(fmt.Sprintf("tag error: %s\n", err)))
+				return DockerImageDigest{}, err
+			}
 		}
 	}
 
 	{
 		var stdoutBuf, stderrBuf bytes.Buffer
 
-		cmd := exec.Command("docker", "push", imageDst)
-		cmd.Stdout = io.MultiWriter(&stdoutBuf, prefixedLogger)
-		cmd.Stderr = io.MultiWriter(&stderrBuf, prefixedLogger)
+		for _, imageTag := range additionalImageTags {
+			cmd := exec.Command("docker", "push", imageTag)
+			cmd.Stdout = io.MultiWriter(&stdoutBuf, prefixedLogger)
+			cmd.Stderr = io.MultiWriter(&stderrBuf, prefixedLogger)
 
-		err := cmd.Run()
-		if err != nil {
-			prefixedLogger.Write([]byte(fmt.Sprintf("push error: %s\n", err)))
-			return DockerImageDigest{}, err
+			err := cmd.Run()
+			if err != nil {
+				prefixedLogger.Write([]byte(fmt.Sprintf("push error: %s\n", err)))
+				return DockerImageDigest{}, err
+			}
 		}
 	}
 
-	currInspectData, err := d.inspect(imageDst)
+	currInspectData, err := d.inspect(fullImageDst)
 	if err != nil {
 		prefixedLogger.Write([]byte(fmt.Sprintf("inspect error: %s\n", err)))
 		return DockerImageDigest{}, err

--- a/pkg/kbld/image/pack.go
+++ b/pkg/kbld/image/pack.go
@@ -89,6 +89,6 @@ func (d Pack) Build(image, directory string, opts PackBuildOpts) (DockerTmpRef, 
 	return d.docker.RetagStable(DockerTmpRef{imageID}, image, imageID, prefixedLogger)
 }
 
-func (d Pack) Push(tmpRef DockerTmpRef, imageDst string) (DockerImageDigest, error) {
-	return d.docker.Push(tmpRef, imageDst)
+func (d Pack) Push(tmpRef DockerTmpRef, imageDst string, additionalImageTags []string) (DockerImageDigest, error) {
+	return d.docker.Push(tmpRef, imageDst, additionalImageTags)
 }

--- a/pkg/kbld/image/pushed.go
+++ b/pkg/kbld/image/pushed.go
@@ -24,7 +24,7 @@ func (i PushedImage) URL() (string, []ImageMeta, error) {
 		return "", nil, err
 	}
 
-	digest, err := i.docker.Push(DockerTmpRef{url}, i.imgDst.NewImage, i.image.ImageTags())
+	digest, err := i.docker.Push(DockerTmpRef{url}, i.imgDst.NewImage, i.image.tags)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/kbld/image/pushed.go
+++ b/pkg/kbld/image/pushed.go
@@ -9,12 +9,12 @@ import (
 
 // PushedImage respresents an image that will be pushed when its URL is requested
 type PushedImage struct {
-	image  BuiltImage
+	image  Image
 	imgDst ctlconf.ImageDestination
 	docker Docker
 }
 
-func NewPushedImage(image BuiltImage, imgDst ctlconf.ImageDestination, docker Docker) PushedImage {
+func NewPushedImage(image Image, imgDst ctlconf.ImageDestination, docker Docker) PushedImage {
 	return PushedImage{image, imgDst, docker}
 }
 

--- a/pkg/kbld/image/pushed.go
+++ b/pkg/kbld/image/pushed.go
@@ -9,12 +9,12 @@ import (
 
 // PushedImage respresents an image that will be pushed when its URL is requested
 type PushedImage struct {
-	image  Image
+	image  BuiltImage
 	imgDst ctlconf.ImageDestination
 	docker Docker
 }
 
-func NewPushedImage(image Image, imgDst ctlconf.ImageDestination, docker Docker) PushedImage {
+func NewPushedImage(image BuiltImage, imgDst ctlconf.ImageDestination, docker Docker) PushedImage {
 	return PushedImage{image, imgDst, docker}
 }
 
@@ -24,7 +24,7 @@ func (i PushedImage) URL() (string, []ImageMeta, error) {
 		return "", nil, err
 	}
 
-	digest, err := i.docker.Push(DockerTmpRef{url}, i.imgDst.NewImage)
+	digest, err := i.docker.Push(DockerTmpRef{url}, i.imgDst.NewImage, i.image.ImageTags())
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/kbld/image/pushed.go
+++ b/pkg/kbld/image/pushed.go
@@ -24,7 +24,7 @@ func (i PushedImage) URL() (string, []ImageMeta, error) {
 		return "", nil, err
 	}
 
-	digest, err := i.docker.Push(DockerTmpRef{url}, i.imgDst.NewImage, i.image.tags)
+	digest, err := i.docker.Push(DockerTmpRef{url}, i.imgDst.NewImage, i.imgDst.Tags)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
Fix #52, the current implementation should serve as a first draft.

Configuration example:

```yaml
apiVersion: kbld.k14s.io/v1alpha1
kind: ImageDestinations
destinations:
- image: demo-service
  newImage: docker.io/starptech/demo-service
  tags:
  - staging
  - v1.0.0
```

Related: https://github.com/k14s/kbld/issues/54