### PR TITLE
Update docs with `--imgpkg-lock-output` flag

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,3 +1,9 @@
+
+### Note: While kbld will continue to provide packaging support for the foreseeable future, most new Carvel users would likely favor [`imgpkg's`](https://github.com/k14s/imgpkg) feature set. To get started with imgpkg, check out the [docs](https://github.com/k14s/imgpkg/tree/develop/docs) as well as how to [produce an ImagesLock file using kbld resolve](resolving.md#generating-resolution-imgpkg-lock-output)
+
+---
+
+
 ## Packaging/relocating images
 
 kbld provides a way to relocate (i.e. copy) images between multiple registries. Two approaches are available:

--- a/docs/resolving.md
+++ b/docs/resolving.md
@@ -62,6 +62,67 @@ kbld -f .
 kbld -f file.yml -f config2.yml
 ```
 
+### Generating resolution `imgpkg` lock output (available in 0.28.0+)
+
+Using the `--imgpkg-lock-output` flag, users are able to create an [ImagesLock](https://github.com/k14s/imgpkg/blob/develop/docs/resources.md#imageslock) file that can be used as input for the packaging and distribution tool: [`imgpkg`](https://github.com/k14s/imgpkg)
+
+
+For example, the command `kbld -f input.yml --imgpkg-lock-output /tmp/imgpkg.lock.yml` with `input.yml`:
+```yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kbld-test1
+spec:
+  selector:
+    matchLabels:
+      app: kbld-test1
+  template:
+    metadata:
+      labels:
+        app: kbld-test1
+    spec:
+      containers:
+      - name: my-app
+        image: nginx:1.14.2
+        #!      ^-- image reference in its tag form
+```
+
+will produce `/tmp/imgpkg.lock.yml`:
+
+```yaml
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: ImagesLock
+spec:
+  images:
+  - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+    annoations:
+      kbld.carvel.dev/ID: nginx:1.14.2
+```
+
+An ImagesLock can be included with configuration via `-f` to produce same resolved configuration, for example, `kbld -f input.yml -f /tmp/imgpkg.lock.yml` produces:
+
+```yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kbld-test1
+spec:
+  selector:
+    matchLabels:
+      app: kbld-test1
+  template:
+    metadata:
+      labels:
+        app: kbld-test1
+    spec:
+      containers:
+      - name: my-app
+        image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+```
+
 ### Generating resolution lock output
 
 In some cases recording resolution results may be useful. To do so add `--lock-output /path-to-file` to the `kbld` command.


### PR DESCRIPTION
Signed-off-by: Garrett Cheadle <gcheadle@vmware.com>