### PR TITLE
Added configuration option for docker buildkit

### DIFF
--- a/pkg/kbld/builder/docker/docker.go
+++ b/pkg/kbld/builder/docker/docker.go
@@ -27,6 +27,7 @@ type DockerBuildOpts struct {
 	Pull       *bool
 	NoCache    *bool
 	File       *string
+	Buildkit   *bool
 	RawOptions *[]string
 }
 
@@ -103,6 +104,10 @@ func (d Docker) Build(image, directory string, opts DockerBuildOpts) (DockerTmpR
 		cmd.Dir = directory
 		cmd.Stdout = io.MultiWriter(&stdoutBuf, prefixedLogger)
 		cmd.Stderr = io.MultiWriter(&stderrBuf, prefixedLogger)
+
+		if opts.Buildkit != nil {
+			cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+		}
 
 		err := cmd.Run()
 		if err != nil {

--- a/pkg/kbld/config/config_docker.go
+++ b/pkg/kbld/config/config_docker.go
@@ -12,5 +12,6 @@ type SourceDockerBuildOpts struct {
 	Pull       *bool
 	NoCache    *bool `json:"noCache"`
 	File       *string
+	Buildkit   *bool
 	RawOptions *[]string `json:"rawOptions"`
 }

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -67,6 +67,7 @@ func (i BuiltImage) URL() (string, []ImageMeta, error) {
 			Pull:       i.buildSource.Docker.Build.Pull,
 			NoCache:    i.buildSource.Docker.Build.NoCache,
 			File:       i.buildSource.Docker.Build.File,
+			Buildkit:   i.buildSource.Docker.Build.Buildkit,
 			RawOptions: i.buildSource.Docker.Build.RawOptions,
 		}
 


### PR DESCRIPTION
Referencing: #81
(Re-opening due to CLA troubles.)

This change adds configuration to enable docker buildkit in the following format:
```
---
apiVersion: kbld.k14s.io/v1alpha1
kind: Config

sources:
- image: foo/bar
  path: bar/
  docker:
    build:
      file: docker/bar/Dockerfile
      buildkit: true
```
Signed-off-by: Andrew Costa ancosta@vmware.com