### PR TITLE
Adding golint and goheader linters via golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,18 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.34
+          args: -v --max-same-issues 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+  enable:
+    - goheader
+    - golint
+  disable-all: true
+# all available settings of specific linters
+linters-settings:
+  goheader:
+    template-path: code-header-template.txt

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,0 +1,2 @@
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/hack/build-and-lint.sh
+++ b/hack/build-and-lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e -x -u
+
+./hack/build.sh
+./hack/linter.sh

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+golangci-lint cache clean
+golangci-lint run --max-same-issues 0

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -4,8 +4,6 @@ set -e -x -u
 
 git --version || (echo "Missing git binary (used by tests)" && exit 1)
 
-./hack/lint.sh
-
 go clean -testcache
 
 go test ./pkg/... -test.v $@

--- a/pkg/kbld/builder/docker/docker.go
+++ b/pkg/kbld/builder/docker/docker.go
@@ -122,11 +122,11 @@ func (d Docker) Build(image, directory string, opts DockerBuildOpts) (DockerTmpR
 		return DockerTmpRef{}, err
 	}
 
-	return d.RetagStable(tmpRef, image, inspectData.Id, prefixedLogger)
+	return d.RetagStable(tmpRef, image, inspectData.ID, prefixedLogger)
 }
 
 func (d Docker) RetagStable(tmpRef DockerTmpRef, image, imageID string,
-	prefixedLogger *ctllog.LoggerPrefixWriter) (DockerTmpRef, error) {
+	prefixedLogger *ctllog.PrefixWriter) (DockerTmpRef, error) {
 
 	tb := ctlb.TagBuilder{}
 
@@ -243,7 +243,7 @@ func (d Docker) Push(tmpRef DockerTmpRef, imageDst string) (DockerImageDigest, e
 	// Try to detect if image we should be pushing isnt the one we ended up pushing
 	// given that its theoretically possible concurrent Docker commands
 	// may have retagged in the middle of the process.
-	if prevInspectData.Id != currInspectData.Id {
+	if prevInspectData.ID != currInspectData.ID {
 		prefixedLogger.Write([]byte(fmt.Sprintf("push race error: %s\n", err)))
 		return DockerImageDigest{}, err
 	}
@@ -267,7 +267,7 @@ func (d Docker) ensureDirectory(directory string) error {
 }
 
 func (d Docker) determineRepoDigest(inspectData dockerInspectData,
-	prefixedLogger *ctllog.LoggerPrefixWriter) (DockerImageDigest, error) {
+	prefixedLogger *ctllog.PrefixWriter) (DockerImageDigest, error) {
 
 	if len(inspectData.RepoDigests) == 0 {
 		prefixedLogger.Write([]byte("missing repo digest\n"))
@@ -289,7 +289,7 @@ func (d Docker) determineRepoDigest(inspectData dockerInspectData,
 		return DockerImageDigest{}, fmt.Errorf("Expected to find same repo digest, but found %#v", inspectData.RepoDigests)
 	}
 
-	for digest, _ := range digestStrs {
+	for digest := range digestStrs {
 		return DockerImageDigest{digest}, nil
 	}
 
@@ -297,7 +297,7 @@ func (d Docker) determineRepoDigest(inspectData dockerInspectData,
 }
 
 type dockerInspectData struct {
-	Id          string
+	ID          string
 	RepoDigests []string
 }
 

--- a/pkg/kbld/cmd/file_flags.go
+++ b/pkg/kbld/cmd/file_flags.go
@@ -20,11 +20,11 @@ func (s *FileFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&s.Sort, "sort", true, "Sort by namespace, name, etc.")
 }
 
-func (f *FileFlags) AllResources() ([]ctlres.Resource, error) {
+func (s *FileFlags) AllResources() ([]ctlres.Resource, error) {
 	var rs []ctlres.Resource
 
 	// TODO do anything with kbld configs?
-	for _, file := range f.Files {
+	for _, file := range s.Files {
 		fileRs, err := ctlres.NewFileResources(file)
 		if err != nil {
 			return nil, err
@@ -45,8 +45,8 @@ func (f *FileFlags) AllResources() ([]ctlres.Resource, error) {
 	return rs, nil
 }
 
-func (f *FileFlags) ResourcesAndConfig() ([]ctlres.Resource, ctlconf.Conf, error) {
-	allRs, err := f.AllResources()
+func (s *FileFlags) ResourcesAndConfig() ([]ctlres.Resource, ctlconf.Conf, error) {
+	allRs, err := s.AllResources()
 	if err != nil {
 		return nil, ctlconf.Conf{}, err
 	}

--- a/pkg/kbld/cmd/image.go
+++ b/pkg/kbld/cmd/image.go
@@ -15,8 +15,8 @@ type Images []Image
 
 type Image struct {
 	URL      string
-	Metas    []ctlimg.ImageMeta // empty when deserialized
-	metasRaw []interface{}      // populated when deserialized
+	Metas    []ctlimg.Meta // empty when deserialized
+	metasRaw []interface{} // populated when deserialized
 }
 
 func (imgs Images) ForImage(url string) (Image, bool) {

--- a/pkg/kbld/cmd/image_set.go
+++ b/pkg/kbld/cmd/image_set.go
@@ -16,7 +16,7 @@ import (
 
 type ImageSet struct {
 	concurrency int
-	logger      *ctllog.LoggerPrefixWriter
+	logger      *ctllog.PrefixWriter
 }
 
 func (o ImageSet) Relocate(foundImages *UnprocessedImageURLs,

--- a/pkg/kbld/cmd/registry_flags.go
+++ b/pkg/kbld/cmd/registry_flags.go
@@ -20,8 +20,8 @@ func (s *RegistryFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&s.Insecure, "registry-insecure", false, "Allow the use of http when interacting with registries")
 }
 
-func (s *RegistryFlags) AsRegistryOpts() ctlreg.RegistryOpts {
-	return ctlreg.RegistryOpts{
+func (s *RegistryFlags) AsRegistryOpts() ctlreg.Opts {
+	return ctlreg.Opts{
 		CACertPaths:   s.CACertPaths,
 		VerifyCerts:   s.VerifyCerts,
 		Insecure:      s.Insecure,

--- a/pkg/kbld/cmd/tar_image_set.go
+++ b/pkg/kbld/cmd/tar_image_set.go
@@ -17,7 +17,7 @@ import (
 type TarImageSet struct {
 	imageSet    ImageSet
 	concurrency int
-	logger      *ctllog.LoggerPrefixWriter
+	logger      *ctllog.PrefixWriter
 }
 
 func (o TarImageSet) Export(foundImages *UnprocessedImageURLs,

--- a/pkg/kbld/cmd/unprocessed_image_urls.go
+++ b/pkg/kbld/cmd/unprocessed_image_urls.go
@@ -25,7 +25,7 @@ func (i *UnprocessedImageURLs) Add(url UnprocessedImageURL) {
 
 func (i *UnprocessedImageURLs) All() []UnprocessedImageURL {
 	var result []UnprocessedImageURL
-	for url, _ := range i.urls {
+	for url := range i.urls {
 		result = append(result, url)
 	}
 	sort.Slice(result, func(i, j int) bool {

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -24,12 +24,12 @@ const (
 	imageKeysKind         = "ImageKeys"
 )
 
-type ConfigKind struct {
+type Kind struct {
 	APIVersion, Kind string
 }
 
 var (
-	configKinds = []ConfigKind{
+	configKinds = []Kind{
 		{configAPIVersion, configKind},
 		{configAPIVersion, configKind},
 		{configAPIVersion, sourcesKind},
@@ -333,9 +333,9 @@ func UniqueImageOverrides(overrides []ImageOverride) []ImageOverride {
 	return result
 }
 
-func (r SearchRule) UpdateStrategyWithDefaults() SearchRuleUpdateStrategy {
-	if r.UpdateStrategy != nil {
-		return *r.UpdateStrategy
+func (d SearchRule) UpdateStrategyWithDefaults() SearchRuleUpdateStrategy {
+	if d.UpdateStrategy != nil {
+		return *d.UpdateStrategy
 	}
 	return SearchRuleUpdateStrategy{
 		EntireString: &SearchRuleUpdateStrategyEntireString{},

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -28,7 +28,7 @@ func NewBuiltImage(url string, buildSource ctlconf.Source, imgDst *ctlconf.Image
 	return BuiltImage{url, buildSource, imgDst, docker, pack, kubectlBuildkit}
 }
 
-func (i BuiltImage) URL() (string, []ImageMeta, error) {
+func (i BuiltImage) URL() (string, []Meta, error) {
 	metas, err := i.sources()
 	if err != nil {
 		return "", nil, err
@@ -80,7 +80,7 @@ func (i BuiltImage) URL() (string, []ImageMeta, error) {
 	}
 }
 
-func (i BuiltImage) optionalPushWithDocker(dockerTmpRef ctlbdk.DockerTmpRef, metas []ImageMeta) (string, []ImageMeta, error) {
+func (i BuiltImage) optionalPushWithDocker(dockerTmpRef ctlbdk.DockerTmpRef, metas []Meta) (string, []Meta, error) {
 	if i.imgDst != nil {
 		digest, err := i.docker.Push(dockerTmpRef, i.imgDst.NewImage)
 		if err != nil {
@@ -115,8 +115,8 @@ type BuiltImageSourceLocal struct {
 
 func (BuiltImageSourceLocal) meta() {}
 
-func (i BuiltImage) sources() ([]ImageMeta, error) {
-	var sources []ImageMeta
+func (i BuiltImage) sources() ([]Meta, error) {
+	var sources []Meta
 
 	absPath, err := filepath.Abs(i.buildSource.Path)
 	if err != nil {

--- a/pkg/kbld/image/digested.go
+++ b/pkg/kbld/image/digested.go
@@ -40,7 +40,7 @@ func NewDigestedImageFromParts(url, digest string) DigestedImage {
 	return DigestedImage{nameWithDigest, nil}
 }
 
-func (i DigestedImage) URL() (string, []ImageMeta, error) {
+func (i DigestedImage) URL() (string, []Meta, error) {
 	if i.parseErr != nil {
 		return "", nil, i.parseErr
 	}

--- a/pkg/kbld/image/factory.go
+++ b/pkg/kbld/image/factory.go
@@ -13,10 +13,10 @@ import (
 )
 
 type Image interface {
-	URL() (string, []ImageMeta, error)
+	URL() (string, []Meta, error)
 }
 
-type ImageMeta interface {
+type Meta interface {
 	meta()
 }
 

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -18,6 +18,6 @@ func NewPreresolvedImage(url string) PreresolvedImage {
 	return PreresolvedImage{url}
 }
 
-func (i PreresolvedImage) URL() (string, []ImageMeta, error) {
-	return i.url, []ImageMeta{PreresolvedImageSourceURL{Type: "preresolved", URL: i.url}}, nil
+func (i PreresolvedImage) URL() (string, []Meta, error) {
+	return i.url, []Meta{PreresolvedImageSourceURL{Type: "preresolved", URL: i.url}}, nil
 }

--- a/pkg/kbld/image/resolved.go
+++ b/pkg/kbld/image/resolved.go
@@ -28,7 +28,7 @@ func NewResolvedImage(url string, registry ctlreg.Registry) ResolvedImage {
 	return ResolvedImage{url, registry}
 }
 
-func (i ResolvedImage) URL() (string, []ImageMeta, error) {
+func (i ResolvedImage) URL() (string, []Meta, error) {
 	tag, err := regname.NewTag(i.url, regname.WeakValidation)
 	if err != nil {
 		return "", nil, err

--- a/pkg/kbld/image/tag_selected.go
+++ b/pkg/kbld/image/tag_selected.go
@@ -24,7 +24,7 @@ func NewTagSelectedImage(url string, selection *versions.VersionSelection,
 	return TagSelectedImage{url, selection, registry}
 }
 
-func (i TagSelectedImage) URL() (string, []ImageMeta, error) {
+func (i TagSelectedImage) URL() (string, []Meta, error) {
 	repo, err := regname.NewRepository(i.url, regname.WeakValidation)
 	if err != nil {
 		return "", nil, err

--- a/pkg/kbld/image/tagged.go
+++ b/pkg/kbld/image/tagged.go
@@ -27,7 +27,7 @@ func NewTaggedImage(image Image, imgDst ctlconf.ImageDestination, registry ctlre
 	return TaggedImage{image, imgDst, registry}
 }
 
-func (i TaggedImage) URL() (string, []ImageMeta, error) {
+func (i TaggedImage) URL() (string, []Meta, error) {
 	url, metas, err := i.image.URL()
 	if err != nil {
 		return "", nil, err

--- a/pkg/kbld/imagetar/tar_file.go
+++ b/pkg/kbld/imagetar/tar_file.go
@@ -28,7 +28,7 @@ type tarFileChunk struct {
 var _ imagedesc.LayerContents = tarFileChunk{}
 
 type tarFileChunkReadCloser struct {
-	DebugId string
+	DebugID string
 	io.Reader
 	io.Closer
 }
@@ -65,7 +65,7 @@ func (f tarFile) openChunk(path string) (io.ReadCloser, error) {
 		}
 		if hdr.Name == path {
 			return tarFileChunkReadCloser{
-				DebugId: fmt.Sprintf("%s/%p", path, tf),
+				DebugID: fmt.Sprintf("%s/%p", path, tf),
 				Reader:  tf, Closer: file}, nil
 		}
 	}

--- a/pkg/kbld/imagetar/tar_writer.go
+++ b/pkg/kbld/imagetar/tar_writer.go
@@ -322,7 +322,7 @@ func (TarWriter) retry(fn func() error) error {
 type zeroReader struct{}
 
 func (r zeroReader) Read(p []byte) (n int, err error) {
-	for i, _ := range p {
+	for i := range p {
 		p[i] = 0
 	}
 	return len(p), nil

--- a/pkg/kbld/logger/logger.go
+++ b/pkg/kbld/logger/logger.go
@@ -19,17 +19,17 @@ func NewLogger(writer io.Writer) Logger {
 	return Logger{writer: writer, writerLock: &sync.Mutex{}}
 }
 
-func (l Logger) NewPrefixedWriter(prefix string) *LoggerPrefixWriter {
-	return &LoggerPrefixWriter{prefix, l.writer, l.writerLock}
+func (l Logger) NewPrefixedWriter(prefix string) *PrefixWriter {
+	return &PrefixWriter{prefix, l.writer, l.writerLock}
 }
 
-type LoggerPrefixWriter struct {
+type PrefixWriter struct {
 	prefix     string
 	writer     io.Writer
 	writerLock *sync.Mutex
 }
 
-func (w *LoggerPrefixWriter) Write(data []byte) (int, error) {
+func (w *PrefixWriter) Write(data []byte) (int, error) {
 	newData := make([]byte, len(data))
 	copy(newData, data)
 
@@ -54,7 +54,7 @@ func (w *LoggerPrefixWriter) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
-func (w *LoggerPrefixWriter) WriteStr(str string, args ...interface{}) error {
+func (w *PrefixWriter) WriteStr(str string, args ...interface{}) error {
 	_, err := w.Write([]byte(fmt.Sprintf(str, args...)))
 	return err
 }

--- a/pkg/kbld/registry/registry.go
+++ b/pkg/kbld/registry/registry.go
@@ -18,7 +18,7 @@ import (
 	regremote "github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-type RegistryOpts struct {
+type Opts struct {
 	CACertPaths   []string
 	VerifyCerts   bool
 	Insecure      bool
@@ -30,7 +30,7 @@ type Registry struct {
 	refOpts []regname.Option
 }
 
-func NewRegistry(opts RegistryOpts) (Registry, error) {
+func NewRegistry(opts Opts) (Registry, error) {
 	keychain := regauthn.NewMultiKeychain(NewEnvKeychain(opts.EnvAuthPrefix), regauthn.DefaultKeychain)
 	transport, err := newHTTPTransport(opts)
 	if err != nil {
@@ -150,7 +150,7 @@ func (i Registry) ListTags(repo regname.Repository) ([]string, error) {
 	return regremote.List(repo, i.opts...)
 }
 
-func newHTTPTransport(opts RegistryOpts) (*http.Transport, error) {
+func newHTTPTransport(opts Opts) (*http.Transport, error) {
 	pool, err := x509.SystemCertPool()
 	if err != nil {
 		pool = x509.NewCertPool()

--- a/pkg/kbld/resources/path.go
+++ b/pkg/kbld/resources/path.go
@@ -135,7 +135,7 @@ func (p Path) Matches(p2 Path) bool {
 	if len(p) != len(p2) {
 		return false
 	}
-	for i, _ := range p {
+	for i := range p {
 		if !p[i].Matches(p2[i]) {
 			return false
 		}
@@ -147,7 +147,7 @@ func (p Path) HasMatchingSuffix(ending Path) bool {
 	if len(p) < len(ending) {
 		return false
 	}
-	for i, _ := range ending {
+	for i := range ending {
 		if !p[len(p)-1-i].Matches(ending[len(ending)-1-i]) {
 			return false
 		}

--- a/pkg/kbld/search/image_refs.go
+++ b/pkg/kbld/search/image_refs.go
@@ -41,10 +41,10 @@ func (v ImageRefsVisitorFunc) Apply(res interface{}, searchRules []ctlconf.Searc
 		}
 		// Only use temporary references for values that are updated;
 		// otherwise future search rules may find tmp refs
-		tmpRefId := fmt.Sprintf(tmpRefPrefix+"%d__", tmpRefIdx)
-		tmpRefs[tmpRefId] = newVal
-		tmpRefIdx += 1
-		return tmpRefId, true
+		tmpRefID := fmt.Sprintf(tmpRefPrefix+"%d__", tmpRefIdx)
+		tmpRefs[tmpRefID] = newVal
+		tmpRefIdx++
+		return tmpRefID, true
 	}
 
 	// Use a single matcher that represents all rules instead


### PR DESCRIPTION
Adding golangci-lint to run `golint` linter to enforce go styling conventions and `goheader` to enforce whether copyright headers are present for files.