### PR TITLE
Fix Copyright Header Linting Errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,4 +15,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.34
-          args: -v --max-same-issues 0
+          args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,6 @@ linters:
 linters-settings:
   goheader:
     template-path: code-header-template.txt
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0 

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -2,4 +2,4 @@
 set -e
 
 golangci-lint cache clean
-golangci-lint run --max-same-issues 0
+golangci-lint run

--- a/pkg/kbld/imageutils/and/and_closer.go
+++ b/pkg/kbld/imageutils/and/and_closer.go
@@ -1,5 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 // Using this code as is from: https://github.com/google/go-containerregistry/tree/master/pkg/v1/internal
 
 // Copyright 2020 Google LLC All Rights Reserved.

--- a/pkg/kbld/imageutils/and/and_closer_test.go
+++ b/pkg/kbld/imageutils/and/and_closer_test.go
@@ -1,5 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 // Using this code as is from: https://github.com/google/go-containerregistry/tree/master/pkg/v1/internal
 
 // Copyright 2020 Google LLC All Rights Reserved.

--- a/pkg/kbld/imageutils/gzip/zip.go
+++ b/pkg/kbld/imageutils/gzip/zip.go
@@ -1,5 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 // Using this code as is from: https://github.com/google/go-containerregistry/tree/master/pkg/v1/internal
 
 // Copyright 2020 Google LLC All Rights Reserved.

--- a/pkg/kbld/imageutils/gzip/zip_test.go
+++ b/pkg/kbld/imageutils/gzip/zip_test.go
@@ -1,5 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 // Using this code as is from: https://github.com/google/go-containerregistry/tree/master/pkg/v1/internal
 
 // Copyright 2020 Google LLC All Rights Reserved.

--- a/pkg/kbld/imageutils/verify/verify.go
+++ b/pkg/kbld/imageutils/verify/verify.go
@@ -1,5 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 // Using this code as is from: https://github.com/google/go-containerregistry/tree/master/pkg/v1/internal
 
 // Copyright 2020 Google LLC All Rights Reserved.

--- a/pkg/kbld/imageutils/verify/verify_test.go
+++ b/pkg/kbld/imageutils/verify/verify_test.go
@@ -1,5 +1,6 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 // Using this code as is from: https://github.com/google/go-containerregistry/tree/master/pkg/v1/internal
 
 // Copyright 2020 Google LLC All Rights Reserved.


### PR DESCRIPTION
Fixing copyright headers format to address linter violations. 