### PR TITLE
Released kbld version can be used in github action

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,4 +1,4 @@
-name: Checks after release is published
+name: Checks after any release is published
 on:
   release:
     types: ['published']
@@ -7,9 +7,10 @@ jobs:
   validate-github-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: k14s/setup-k14s-action@v1
+      - uses: vmware-tanzu/carvel-setup-action@v1
         with:
           only: kbld
+          kbld: ${{ github.event.release.tag_name }}
       - run: |
           kbld version
           version=`kbld version`
@@ -17,7 +18,7 @@ jobs:
           tool_version="$(echo $version | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')"
           if [[ "v${tool_version}" == "${tag}" ]];
           then
-            echo "Version match with latest"
+            echo "Version match with $tag"
             exit 0
           else
             echo "Versions do not match v$tool_version != $tag"


### PR DESCRIPTION
Add a tag download validation to ensure that the version being released is the retrieved
Start using the new github action