### PR TITLE
Add metadata in imgpkg lock file

### DIFF
--- a/pkg/kbld/cmd/image.go
+++ b/pkg/kbld/cmd/image.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	ctlconf "github.com/k14s/kbld/pkg/kbld/config"
 	ctlimg "github.com/k14s/kbld/pkg/kbld/image"
 	"sigs.k8s.io/yaml"
 )
@@ -36,6 +37,21 @@ func (i Image) Description() string {
 	}
 
 	return strings.TrimSpace(string(yamlBytes))
+}
+
+func (i Image) MetasDescription() []ctlconf.ImageMeta {
+	imageMetas, err := yaml.Marshal(i.Metas)
+	if err != nil {
+		return nil
+	}
+
+	var metas []ctlconf.ImageMeta
+	err = yaml.Unmarshal(imageMetas, &metas)
+	if err != nil {
+		return nil
+	}
+
+	return metas
 }
 
 type imageStruct struct {

--- a/pkg/kbld/cmd/image.go
+++ b/pkg/kbld/cmd/image.go
@@ -16,7 +16,7 @@ type Images []Image
 type Image struct {
 	URL      string
 	Metas    []ctlconf.Meta // empty when deserialized
-	metasRaw []interface{} // populated when deserialized
+	metasRaw []interface{}  // populated when deserialized
 }
 
 func (imgs Images) ForImage(url string) (Image, bool) {

--- a/pkg/kbld/cmd/image.go
+++ b/pkg/kbld/cmd/image.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	ctlconf "github.com/k14s/kbld/pkg/kbld/config"
-	ctlimg "github.com/k14s/kbld/pkg/kbld/image"
 	"sigs.k8s.io/yaml"
 )
 
@@ -16,7 +15,7 @@ type Images []Image
 
 type Image struct {
 	URL      string
-	Metas    []ctlimg.Meta // empty when deserialized
+	Metas    []ctlconf.Meta // empty when deserialized
 	metasRaw []interface{} // populated when deserialized
 }
 
@@ -37,21 +36,6 @@ func (i Image) Description() string {
 	}
 
 	return strings.TrimSpace(string(yamlBytes))
-}
-
-func (i Image) MetasDescription() []ctlconf.ImageMeta {
-	imageMetas, err := yaml.Marshal(i.Metas)
-	if err != nil {
-		return nil
-	}
-
-	var metas []ctlconf.ImageMeta
-	err = yaml.Unmarshal(imageMetas, &metas)
-	if err != nil {
-		return nil
-	}
-
-	return metas
 }
 
 type imageStruct struct {

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -235,8 +235,6 @@ func (o *ResolveOptions) emitLockOutput(conf ctlconf.Conf, resolvedImages *Proce
 			})
 		}
 
-		c.Overrides = ctlconf.UniqueImageOverrides(c.Overrides)
-
 		return c.WriteToFile(o.LockOutput)
 	case o.ImgpkgLockOutput != "":
 		iLock := lockconfig.ImagesLock{

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -246,7 +246,7 @@ func (o *ResolveOptions) emitLockOutput(conf ctlconf.Conf, resolvedImages *Proce
 			},
 		}
 		for _, urlImagePair := range resolvedImages.All() {
-			anns := imgpkgLockAnnotations(urlImagePair)
+			anns := o.imgpkgLockAnnotations(urlImagePair)
 
 			iLock.Images = append(iLock.Images, lockconfig.ImageRef{
 				Image:       urlImagePair.Image.URL,
@@ -259,7 +259,7 @@ func (o *ResolveOptions) emitLockOutput(conf ctlconf.Conf, resolvedImages *Proce
 	}
 }
 
-func imgpkgLockAnnotations(i ProcessedImageItem) map[string]string {
+func (o *ResolveOptions) imgpkgLockAnnotations(i ProcessedImageItem) map[string]string {
 	anns := map[string]string{
 		ctlconf.ImagesLockKbldID: i.UnprocessedImageURL.URL,
 	}

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -263,14 +263,9 @@ func (o *ResolveOptions) imgpkgLockAnnotations(i ProcessedImageItem) map[string]
 	anns := map[string]string{
 		ctlconf.ImagesLockKbldID: i.UnprocessedImageURL.URL,
 	}
-
-	imageMetas := i.Image.MetasDescription()
-	if imageMetas != nil && len(imageMetas) > 0 {
-		var metas []ctlconf.ImageMeta
-		for _, m := range imageMetas {
-			metas = append(metas, m)
-		}
-		metaYaml, err := yaml.Marshal(metas)
+	imageMetas := i.Metas
+	if len(imageMetas) > 0 {
+		metaYaml, err := yaml.Marshal(imageMetas)
 		if err != nil {
 			return anns
 		}

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -266,13 +266,15 @@ func (o *ResolveOptions) imgpkgLockAnnotations(i ProcessedImageItem) map[string]
 
 	imageMetas := i.Image.MetasDescription()
 	if imageMetas != nil && len(imageMetas) > 0 {
-		metaYaml, err := yaml.Marshal([]ctlconf.ImageMeta{
-			{
-				URL:  imageMetas[0].URL,
-				Type: "preresolved",
-				Tag:  imageMetas[0].Tag,
-			},
-		})
+		var metas []ctlconf.ImageMeta
+		for _, m := range imageMetas {
+			metas = append(metas, ctlconf.ImageMeta{
+				URL:  m.URL,
+				Type: m.Type,
+				Tag:  m.Tag,
+			})
+		}
+		metaYaml, err := yaml.Marshal(metas)
 		if err != nil {
 			return anns
 		}

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -20,6 +20,7 @@ import (
 	ctlser "github.com/k14s/kbld/pkg/kbld/search"
 	"github.com/k14s/kbld/pkg/kbld/version"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 )
 
 type ResolveOptions struct {
@@ -245,9 +246,16 @@ func (o *ResolveOptions) emitLockOutput(conf ctlconf.Conf, resolvedImages *Proce
 			},
 		}
 		for _, urlImagePair := range resolvedImages.All() {
+			imagesYAML, err := yaml.Marshal(urlImagePair.Image.Metas)
+			if err != nil {
+				return err
+			}
 			iLock.Images = append(iLock.Images, lockconfig.ImageRef{
-				Image:       urlImagePair.Image.URL,
-				Annotations: map[string]string{ctlconf.ImagesLockKbldID: urlImagePair.UnprocessedImageURL.URL},
+				Image: urlImagePair.Image.URL,
+				Annotations: map[string]string{
+					ctlconf.ImagesLockKbldID:    urlImagePair.UnprocessedImageURL.URL,
+					ctlconf.ImagesLockKbldMetas: string(imagesYAML),
+				},
 			})
 		}
 		return iLock.WriteToPath(o.ImgpkgLockOutput)

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -268,11 +268,7 @@ func (o *ResolveOptions) imgpkgLockAnnotations(i ProcessedImageItem) map[string]
 	if imageMetas != nil && len(imageMetas) > 0 {
 		var metas []ctlconf.ImageMeta
 		for _, m := range imageMetas {
-			metas = append(metas, ctlconf.ImageMeta{
-				URL:  m.URL,
-				Type: m.Type,
-				Tag:  m.Tag,
-			})
+			metas = append(metas, m)
 		}
 		metaYaml, err := yaml.Marshal(metas)
 		if err != nil {

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -246,11 +246,9 @@ func (o *ResolveOptions) emitLockOutput(conf ctlconf.Conf, resolvedImages *Proce
 			},
 		}
 		for _, urlImagePair := range resolvedImages.All() {
-			anns := o.imgpkgLockAnnotations(urlImagePair)
-
 			iLock.Images = append(iLock.Images, lockconfig.ImageRef{
 				Image:       urlImagePair.Image.URL,
-				Annotations: anns,
+				Annotations: o.imgpkgLockAnnotations(urlImagePair),
 			})
 		}
 		return iLock.WriteToPath(o.ImgpkgLockOutput)
@@ -263,13 +261,12 @@ func (o *ResolveOptions) imgpkgLockAnnotations(i ProcessedImageItem) map[string]
 	anns := map[string]string{
 		ctlconf.ImagesLockKbldID: i.UnprocessedImageURL.URL,
 	}
-	imageMetas := i.Metas
-	if len(imageMetas) > 0 {
-		metaYaml, err := yaml.Marshal(imageMetas)
+	if len(i.Metas) > 0 {
+		bs, err := yaml.Marshal(i.Metas)
 		if err != nil {
 			return anns
 		}
-		anns[ctlconf.ImagesLockKbldMetas] = string(metaYaml)
+		anns[ctlconf.ImagesLockKbldMetas] = string(bs)
 	}
 
 	return anns

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -73,9 +73,14 @@ type ImageOverride struct {
 }
 
 type ImageMeta struct {
-	URL  string `json:"URL,omitempty" yaml:"URL,omitempty"`
-	Type string `json:"Type,omitempty" yaml:"Type,omitempty"`
-	Tag  string `json:"Tag,omitempty" yaml:"Tag,omitempty"`
+	URL       string   `json:",omitempty" yaml:",omitempty"`
+	Type      string   `json:",omitempty" yaml:",omitempty"`
+	Tag       string   `json:",omitempty" yaml:",omitempty"`
+	Path      string   `json:",omitempty" yaml:",omitempty"`
+	RemoteURL string   `json:",omitempty" yaml:",omitempty"`
+	SHA       string   `json:",omitempty" yaml:",omitempty"`
+	Dirty     bool     `json:",omitempty" yaml:",omitempty"`
+	Tags      []string `json:",omitempty" yaml:",omitempty"`
 }
 
 type ImageDestination struct {

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -69,18 +69,7 @@ type ImageOverride struct {
 	NewImage     string                     `json:"newImage"`
 	Preresolved  bool                       `json:"preresolved,omitempty"`
 	TagSelection *versions.VersionSelection `json:"tagSelection,omitempty"`
-	ImageMetas   []ImageMeta                `json:",omitempty"`
-}
-
-type ImageMeta struct {
-	URL       string   `json:",omitempty" yaml:",omitempty"`
-	Type      string   `json:",omitempty" yaml:",omitempty"`
-	Tag       string   `json:",omitempty" yaml:",omitempty"`
-	Path      string   `json:",omitempty" yaml:",omitempty"`
-	RemoteURL string   `json:",omitempty" yaml:",omitempty"`
-	SHA       string   `json:",omitempty" yaml:",omitempty"`
-	Dirty     bool     `json:",omitempty" yaml:",omitempty"`
-	Tags      []string `json:",omitempty" yaml:",omitempty"`
+	ImageMetas   []Meta                     `json:",omitempty"`
 }
 
 type ImageDestination struct {
@@ -181,10 +170,9 @@ func NewConfigFromImagesLock(res ctlres.Resource) (Config, error) {
 	overridesConfig := NewConfig()
 
 	for _, image := range imagesLock.Images {
-		var iMetas []ImageMeta
-		err := yaml.Unmarshal([]byte(image.Annotations[ImagesLockKbldMetas]), &iMetas)
+		imageMeta, err := metasHistory(image.Annotations[ImagesLockKbldMetas])
 		if err != nil {
-			return Config{}, fmt.Errorf("Unmarshaling %s metas annotation: %s", res.Description(), err)
+			return Config{}, fmt.Errorf("Unmarshaling %s as %s annotation:  %s", res.Description(), ImagesLockKbldMetas, err)
 		}
 		iOverride := ImageOverride{
 			ImageRef: ImageRef{
@@ -192,7 +180,7 @@ func NewConfigFromImagesLock(res ctlres.Resource) (Config, error) {
 			},
 			NewImage:    image.Image,
 			Preresolved: true,
-			ImageMetas:  iMetas,
+			ImageMetas:  imageMeta,
 		}
 		overridesConfig.Overrides = append(overridesConfig.Overrides, iOverride)
 	}

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -6,7 +6,6 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
-	"reflect"
 
 	semver "github.com/hashicorp/go-version"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
@@ -325,13 +324,21 @@ func (d Config) WriteToFile(path string) error {
 	return nil
 }
 
+// Equal reports whether this ImageOverride is equal to another ImageOverride.
+//   (`ImageMeta` is descriptive — not identifying — so not part of equality)
+func (d ImageOverride) Equal(other ImageOverride) bool {
+	return d.ImageRef == other.ImageRef &&
+		d.NewImage == other.NewImage &&
+		d.Preresolved == other.Preresolved &&
+		d.TagSelection == other.TagSelection
+}
+
 func UniqueImageOverrides(overrides []ImageOverride) []ImageOverride {
 	var result []ImageOverride
 	for _, override := range overrides {
 		var found bool
 		for _, addedOverride := range result {
-			// using DeepEqual instead of '==' since ImageOverride contains a slice
-			if reflect.DeepEqual(addedOverride, override) {
+			if override.Equal(addedOverride) {
 				found = true
 				break
 			}

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -177,7 +177,10 @@ func NewConfigFromImagesLock(res ctlres.Resource) (Config, error) {
 
 	for _, image := range imagesLock.Images {
 		var iMetas []ImageMeta
-		yaml.Unmarshal([]byte(image.Annotations[ImagesLockKbldMetas]), &iMetas)
+		err := yaml.Unmarshal([]byte(image.Annotations[ImagesLockKbldMetas]), &iMetas)
+		if err != nil {
+			return Config{}, fmt.Errorf("Unmarshaling %s metas annotation: %s", res.Description(), err)
+		}
 		iOverride := ImageOverride{
 			ImageRef: ImageRef{
 				Image: image.Annotations[ImagesLockKbldID],

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -73,9 +73,9 @@ type ImageOverride struct {
 }
 
 type ImageMeta struct {
-	URL  string `json:"URL,omitempty"`
-	Type string `json:"Type,omitempty"`
-	Tag  string `json:"Tag,omitempty"`
+	URL  string `json:"URL,omitempty" yaml:"URL,omitempty"`
+	Type string `json:"Type,omitempty" yaml:"Type,omitempty"`
+	Tag  string `json:"Tag,omitempty" yaml:"Tag,omitempty"`
 }
 
 type ImageDestination struct {

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -69,13 +69,13 @@ type ImageOverride struct {
 	NewImage     string                     `json:"newImage"`
 	Preresolved  bool                       `json:"preresolved,omitempty"`
 	TagSelection *versions.VersionSelection `json:"tagSelection,omitempty"`
-	ImageMetas   []ImageMeta
+	ImageMetas   []ImageMeta                `json:",omitempty"`
 }
 
 type ImageMeta struct {
-	URL  string `json:"URL"`
-	Type string `json:"Type"`
-	Tag  string `json:"Tag"`
+	URL  string `json:"URL,omitempty"`
+	Type string `json:"Type,omitempty"`
+	Tag  string `json:"Tag,omitempty"`
 }
 
 type ImageDestination struct {

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -69,7 +69,7 @@ type ImageOverride struct {
 	NewImage     string                     `json:"newImage"`
 	Preresolved  bool                       `json:"preresolved,omitempty"`
 	TagSelection *versions.VersionSelection `json:"tagSelection,omitempty"`
-	ImageMetas   []Meta                     `json:",omitempty"`
+	ImageMetas   []Meta                     `json:"metas,omitempty"`
 }
 
 type ImageDestination struct {
@@ -170,7 +170,7 @@ func NewConfigFromImagesLock(res ctlres.Resource) (Config, error) {
 	overridesConfig := NewConfig()
 
 	for _, image := range imagesLock.Images {
-		imageMeta, err := metasHistory(image.Annotations[ImagesLockKbldMetas])
+		imgMeta, err := NewMetasFromString(image.Annotations[ImagesLockKbldMetas])
 		if err != nil {
 			return Config{}, fmt.Errorf("Unmarshaling %s as %s annotation:  %s", res.Description(), ImagesLockKbldMetas, err)
 		}
@@ -180,7 +180,7 @@ func NewConfigFromImagesLock(res ctlres.Resource) (Config, error) {
 			},
 			NewImage:    image.Image,
 			Preresolved: true,
-			ImageMetas:  imageMeta,
+			ImageMetas:  imgMeta,
 		}
 		overridesConfig.Overrides = append(overridesConfig.Overrides, iOverride)
 	}

--- a/pkg/kbld/config/image_meta.go
+++ b/pkg/kbld/config/image_meta.go
@@ -13,12 +13,20 @@ type Meta interface {
 	meta()
 }
 
-type ImageMeta struct {
+type imageMeta struct {
 	Metas []Meta
 }
 
+const (
+	GitMeta         = "git"
+	LocalMeta       = "local"
+	ResolvedMeta    = "resolved"
+	TaggedMeta      = "tagged"
+	PreresolvedMeta = "preresolved"
+)
+
 type BuiltImageSourceGit struct {
-	Type      string // always set to 'git'
+	Type      string // always set to GitMeta
 	RemoteURL string `json:",omitempty" yaml:",omitempty"`
 	SHA       string
 	Dirty     bool
@@ -26,23 +34,23 @@ type BuiltImageSourceGit struct {
 }
 
 type BuiltImageSourceLocal struct {
-	Type string // always set to 'local'
+	Type string // always set to LocalMeta
 	Path string
 }
 
 type ResolvedImageSourceURL struct {
-	Type string // always set to 'resolved'
+	Type string // always set to ResolvedMeta
 	URL  string
 	Tag  string
 }
 
 type TaggedImageMeta struct {
-	Type string // always set to 'tagged'
+	Type string // always set to TaggedMeta
 	Tags []string
 }
 
 type PreresolvedImageSourceURL struct {
-	Type string // always set to 'preresolved'
+	Type string // always set to PreresolvedMeta
 	URL  string
 	Tag  string `json:",omitempty" yaml:",omitempty"`
 }
@@ -53,18 +61,18 @@ func (ResolvedImageSourceURL) meta()    {}
 func (TaggedImageMeta) meta()           {}
 func (PreresolvedImageSourceURL) meta() {}
 
-func metasHistory(metas string) ([]Meta, error) {
-	imageMeta := ImageMeta{}
-	err := yaml.Unmarshal([]byte(metas), &imageMeta)
+func NewMetasFromString(metas string) ([]Meta, error) {
+	imgMeta := imageMeta{}
+	err := yaml.Unmarshal([]byte(metas), &imgMeta)
 	if err != nil {
 		return []Meta{}, err
 	}
-	return imageMeta.Metas, nil
+	return imgMeta.Metas, nil
 }
 
-var _ json.Unmarshaler = &ImageMeta{}
+var _ json.Unmarshaler = &imageMeta{}
 
-func (m *ImageMeta) UnmarshalJSON(data []byte) error {
+func (m *imageMeta) UnmarshalJSON(data []byte) error {
 	var list []interface{}
 	err := yaml.Unmarshal(data, &list)
 	if err != nil {
@@ -81,16 +89,31 @@ func (m *ImageMeta) UnmarshalJSON(data []byte) error {
 		yamlItem, _ := yaml.Marshal(&item)
 
 		switch {
-		case yaml.Unmarshal(yamlItem, &local) == nil && local.Type == "local":
+		case yaml.Unmarshal(yamlItem, &local) == nil && local.Type == LocalMeta:
 			m.Metas = append(m.Metas, local)
-		case yaml.Unmarshal(yamlItem, &git) == nil && git.Type == "git":
+		case yaml.Unmarshal(yamlItem, &git) == nil && git.Type == GitMeta:
 			m.Metas = append(m.Metas, git)
-		case yaml.Unmarshal(yamlItem, &res) == nil && res.Type == "resolved":
+		case yaml.Unmarshal(yamlItem, &res) == nil && res.Type == ResolvedMeta:
 			m.Metas = append(m.Metas, res)
-		case yaml.Unmarshal(yamlItem, &preres) == nil && preres.Type == "preresolved":
+		case yaml.Unmarshal(yamlItem, &preres) == nil && preres.Type == PreresolvedMeta:
 			m.Metas = append(m.Metas, preres)
-		case yaml.Unmarshal(yamlItem, &tag) == nil && tag.Type == "tagged":
+		case yaml.Unmarshal(yamlItem, &tag) == nil && tag.Type == TaggedMeta:
 			m.Metas = append(m.Metas, tag)
+		default:
+			// ignore unknown meta.
+			// At this time...
+			// - "Meta" are provided as primarily optional diagnostic information
+			//   rather than operational data (read: less important). Losing
+			//   this information does not change the correctness of kbld's
+			//   primary purpose during deployment: to rewrite image references.
+			//   It would be more than an annoyance to error-out if we were
+			//   unable to parse such data.
+			// - Ideally, yes, we'd at least report a warning. However, if there's
+			//   a systemic condition (e.g. using an older version of kbld to
+			//   deploy than was used to package) there would likely be a flurry
+			//   of warnings. So, the feature would quickly need an enhancement
+			//   to de-dup such warnings. (read: added complexity)
+			// see also https://github.com/vmware-tanzu/carvel-kbld/issues/160
 		}
 	}
 	return nil

--- a/pkg/kbld/config/image_meta.go
+++ b/pkg/kbld/config/image_meta.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/kbld/config/image_meta.go
+++ b/pkg/kbld/config/image_meta.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+type Meta interface {
+	meta()
+}
+
+type ImageMeta struct {
+	Metas []Meta
+}
+
+type BuiltImageSourceGit struct {
+	Type      string // always set to 'git'
+	RemoteURL string `json:",omitempty" yaml:",omitempty"`
+	SHA       string
+	Dirty     bool
+	Tags      []string `json:",omitempty" yaml:",omitempty"`
+}
+
+type BuiltImageSourceLocal struct {
+	Type string // always set to 'local'
+	Path string
+}
+
+type ResolvedImageSourceURL struct {
+	Type string // always set to 'resolved'
+	URL  string
+	Tag  string
+}
+
+type TaggedImageMeta struct {
+	Type string // always set to 'tagged'
+	Tags []string
+}
+
+type PreresolvedImageSourceURL struct {
+	Type string // always set to 'preresolved'
+	URL  string
+	Tag  string `json:",omitempty" yaml:",omitempty"`
+}
+
+func (BuiltImageSourceGit) meta()       {}
+func (BuiltImageSourceLocal) meta()     {}
+func (ResolvedImageSourceURL) meta()    {}
+func (TaggedImageMeta) meta()           {}
+func (PreresolvedImageSourceURL) meta() {}
+
+func metasHistory(metas string) ([]Meta, error) {
+	imageMeta := ImageMeta{}
+	err := yaml.Unmarshal([]byte(metas), &imageMeta)
+	if err != nil {
+		return []Meta{}, err
+	}
+	return imageMeta.Metas, nil
+}
+
+var _ json.Unmarshaler = &ImageMeta{}
+
+func (m *ImageMeta) UnmarshalJSON(data []byte) error {
+	var list []interface{}
+	err := yaml.Unmarshal(data, &list)
+	if err != nil {
+		return err
+	}
+
+	var local BuiltImageSourceLocal
+	var git BuiltImageSourceGit
+	var res ResolvedImageSourceURL
+	var preres PreresolvedImageSourceURL
+	var tag TaggedImageMeta
+
+	for _, item := range list {
+		yamlItem, _ := yaml.Marshal(&item)
+		switch {
+		case yaml.Unmarshal(yamlItem, &local) == nil && local.Type == "local":
+			m.Metas = append(m.Metas, local)
+		case yaml.Unmarshal(yamlItem, &git) == nil && git.Type == "git":
+			m.Metas = append(m.Metas, git)
+		case yaml.Unmarshal(yamlItem, &res) == nil && res.Type == "resolved":
+			m.Metas = append(m.Metas, res)
+		case yaml.Unmarshal(yamlItem, &preres) == nil && preres.Type == "preresolved":
+			m.Metas = append(m.Metas, preres)
+		case yaml.Unmarshal(yamlItem, &tag) == nil && tag.Type == "tagged":
+			m.Metas = append(m.Metas, tag)
+		default:
+			return fmt.Errorf("Unknown Image Meta")
+		}
+	}
+	return nil
+}

--- a/pkg/kbld/config/image_meta.go
+++ b/pkg/kbld/config/image_meta.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"sigs.k8s.io/yaml"
 )
@@ -72,14 +71,15 @@ func (m *ImageMeta) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	var local BuiltImageSourceLocal
-	var git BuiltImageSourceGit
-	var res ResolvedImageSourceURL
-	var preres PreresolvedImageSourceURL
-	var tag TaggedImageMeta
-
 	for _, item := range list {
+		var local BuiltImageSourceLocal
+		var git BuiltImageSourceGit
+		var res ResolvedImageSourceURL
+		var preres PreresolvedImageSourceURL
+		var tag TaggedImageMeta
+
 		yamlItem, _ := yaml.Marshal(&item)
+
 		switch {
 		case yaml.Unmarshal(yamlItem, &local) == nil && local.Type == "local":
 			m.Metas = append(m.Metas, local)
@@ -91,8 +91,6 @@ func (m *ImageMeta) UnmarshalJSON(data []byte) error {
 			m.Metas = append(m.Metas, preres)
 		case yaml.Unmarshal(yamlItem, &tag) == nil && tag.Type == "tagged":
 			m.Metas = append(m.Metas, tag)
-		default:
-			return fmt.Errorf("Unknown Image Meta")
 		}
 	}
 	return nil

--- a/pkg/kbld/config/images_lock.go
+++ b/pkg/kbld/config/images_lock.go
@@ -4,5 +4,6 @@
 package config
 
 const (
-	ImagesLockKbldID = "kbld.carvel.dev/id"
+	ImagesLockKbldID    = "kbld.carvel.dev/id"
+	ImagesLockKbldMetas = "kbld.carvel.dev/metas"
 )

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -32,7 +32,7 @@ func NewBuiltImage(url string, buildSource ctlconf.Source, imgDst *ctlconf.Image
 	return BuiltImage{url, buildSource, imgDst, docker, pack, kubectlBuildkit, ko, bazel}
 }
 
-func (i BuiltImage) URL() (string, []Meta, error) {
+func (i BuiltImage) URL() (string, []ctlconf.Meta, error) {
 	metas, err := i.sources()
 	if err != nil {
 		return "", nil, err
@@ -100,7 +100,7 @@ func (i BuiltImage) URL() (string, []Meta, error) {
 	}
 }
 
-func (i BuiltImage) optionalPushWithDocker(dockerTmpRef ctlbdk.DockerTmpRef, metas []Meta) (string, []Meta, error) {
+func (i BuiltImage) optionalPushWithDocker(dockerTmpRef ctlbdk.DockerTmpRef, metas []ctlconf.Meta) (string, []ctlconf.Meta, error) {
 	if i.imgDst != nil {
 		digest, err := i.docker.Push(dockerTmpRef, i.imgDst.NewImage)
 		if err != nil {
@@ -118,32 +118,15 @@ func (i BuiltImage) optionalPushWithDocker(dockerTmpRef ctlbdk.DockerTmpRef, met
 	return dockerTmpRef.AsString(), metas, nil
 }
 
-type BuiltImageSourceGit struct {
-	Type      string // always set to 'git'
-	RemoteURL string `json:",omitempty" yaml:",omitempty"`
-	SHA       string
-	Dirty     bool
-	Tags      []string `json:",omitempty" yaml:",omitempty"`
-}
-
-func (BuiltImageSourceGit) meta() {}
-
-type BuiltImageSourceLocal struct {
-	Type string // always set to 'local'
-	Path string
-}
-
-func (BuiltImageSourceLocal) meta() {}
-
-func (i BuiltImage) sources() ([]Meta, error) {
-	var sources []Meta
+func (i BuiltImage) sources() ([]ctlconf.Meta, error) {
+	var sources []ctlconf.Meta
 
 	absPath, err := filepath.Abs(i.buildSource.Path)
 	if err != nil {
 		return nil, err
 	}
 
-	sources = append(sources, BuiltImageSourceLocal{
+	sources = append(sources, ctlconf.BuiltImageSourceLocal{
 		Type: "local",
 		Path: absPath,
 	})
@@ -152,7 +135,7 @@ func (i BuiltImage) sources() ([]Meta, error) {
 
 	if gitRepo.IsValid() {
 		var err error
-		git := BuiltImageSourceGit{Type: "git"}
+		git := ctlconf.BuiltImageSourceGit{Type: "git"}
 
 		git.RemoteURL, err = gitRepo.RemoteURL()
 		if err != nil {

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -127,7 +127,7 @@ func (i BuiltImage) sources() ([]ctlconf.Meta, error) {
 	}
 
 	sources = append(sources, ctlconf.BuiltImageSourceLocal{
-		Type: "local",
+		Type: ctlconf.LocalMeta,
 		Path: absPath,
 	})
 
@@ -135,7 +135,7 @@ func (i BuiltImage) sources() ([]ctlconf.Meta, error) {
 
 	if gitRepo.IsValid() {
 		var err error
-		git := ctlconf.BuiltImageSourceGit{Type: "git"}
+		git := ctlconf.BuiltImageSourceGit{Type: ctlconf.GitMeta}
 
 		git.RemoteURL, err = gitRepo.RemoteURL()
 		if err != nil {

--- a/pkg/kbld/image/digested.go
+++ b/pkg/kbld/image/digested.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	regname "github.com/google/go-containerregistry/pkg/name"
+	ctlconf "github.com/k14s/kbld/pkg/kbld/config"
 )
 
 const digestSep = "@"
@@ -40,7 +41,7 @@ func NewDigestedImageFromParts(url, digest string) DigestedImage {
 	return DigestedImage{nameWithDigest, nil}
 }
 
-func (i DigestedImage) URL() (string, []Meta, error) {
+func (i DigestedImage) URL() (string, []ctlconf.Meta, error) {
 	if i.parseErr != nil {
 		return "", nil, i.parseErr
 	}

--- a/pkg/kbld/image/factory.go
+++ b/pkg/kbld/image/factory.go
@@ -36,7 +36,7 @@ func (f Factory) New(url string) Image {
 	if overrideConf, found := f.shouldOverride(url); found {
 		url = overrideConf.NewImage
 		if overrideConf.Preresolved {
-			return NewPreresolvedImage(url)
+			return NewPreresolvedImage(url, overrideConf.ImageMetas)
 		} else if overrideConf.TagSelection != nil {
 			return NewTagSelectedImage(url, overrideConf.TagSelection, f.registry)
 		}

--- a/pkg/kbld/image/factory.go
+++ b/pkg/kbld/image/factory.go
@@ -15,11 +15,7 @@ import (
 )
 
 type Image interface {
-	URL() (string, []Meta, error)
-}
-
-type Meta interface {
-	meta()
+	URL() (string, []ctlconf.Meta, error)
 }
 
 type Factory struct {

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -25,12 +25,12 @@ func NewPreresolvedImage(url string, metas []config.ImageMeta) PreresolvedImage 
 }
 
 func (i PreresolvedImage) URL() (string, []Meta, error) {
-	if len(i.metas) > 0 {
-		var imageMetas []Meta
-		for _, m := range i.metas {
-			imageMetas = append(imageMetas, PreresolvedImageSourceURL{Type: "preresolved", URL: m.URL, Tag: m.Tag})
-		}
-		return i.url, imageMetas, nil
+	var imageMetas []Meta
+	for _, m := range i.metas {
+		imageMetas = append(imageMetas, PreresolvedImageSourceURL{Type: m.Type, URL: m.URL, Tag: m.Tag})
 	}
-	return i.url, []Meta{PreresolvedImageSourceURL{Type: "preresolved", URL: i.url}}, nil
+	imageMetas = append(imageMetas, PreresolvedImageSourceURL{Type: "preresolved", URL: i.url})
+
+	return i.url, imageMetas, nil
+
 }

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -4,33 +4,20 @@
 package image
 
 import (
-	"github.com/k14s/kbld/pkg/kbld/config"
+	ctlconf "github.com/k14s/kbld/pkg/kbld/config"
 )
 
 type PreresolvedImage struct {
 	url   string
-	metas []config.ImageMeta
+	metas []ctlconf.Meta
 }
 
-type PreresolvedImageSourceURL struct {
-	Type string // always set to 'preresolved'
-	URL  string
-	Tag  string `json:",omitempty" yaml:",omitempty"`
-}
-
-func (PreresolvedImageSourceURL) meta() {}
-
-func NewPreresolvedImage(url string, metas []config.ImageMeta) PreresolvedImage {
+func NewPreresolvedImage(url string, metas []ctlconf.Meta) PreresolvedImage {
 	return PreresolvedImage{url, metas}
 }
 
-func (i PreresolvedImage) URL() (string, []Meta, error) {
-	var imageMetas []Meta
-	for _, m := range i.metas {
-		imageMetas = append(imageMetas, PreresolvedImageSourceURL{Type: m.Type, URL: m.URL, Tag: m.Tag})
-	}
-	imageMetas = append(imageMetas, PreresolvedImageSourceURL{Type: "preresolved", URL: i.url})
+func (i PreresolvedImage) URL() (string, []ctlconf.Meta, error) {
+	imageMetas := append(i.metas, ctlconf.PreresolvedImageSourceURL{Type: "preresolved", URL: i.url})
 
 	return i.url, imageMetas, nil
-
 }

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -3,21 +3,35 @@
 
 package image
 
+import (
+	"github.com/k14s/kbld/pkg/kbld/config"
+)
+
 type PreresolvedImage struct {
-	url string
+	url   string
+	metas []config.ImageMeta
 }
 
 type PreresolvedImageSourceURL struct {
 	Type string // always set to 'preresolved'
 	URL  string
+	Tag  string `json:",omitempty" yaml:",omitempty"`
 }
 
 func (PreresolvedImageSourceURL) meta() {}
 
-func NewPreresolvedImage(url string) PreresolvedImage {
-	return PreresolvedImage{url}
+func NewPreresolvedImage(url string, metas []config.ImageMeta) PreresolvedImage {
+	return PreresolvedImage{url, metas}
 }
 
 func (i PreresolvedImage) URL() (string, []Meta, error) {
+	if len(i.metas) > 0 {
+		var givenMetas []Meta
+		for _, m := range i.metas {
+			//TODO: should we change Type to 'preresolved' or keep whatever is given from lockfile?
+			givenMetas = append(givenMetas, PreresolvedImageSourceURL{Type: m.Type, URL: m.URL, Tag: m.Tag})
+		}
+		return i.url, givenMetas, nil
+	}
 	return i.url, []Meta{PreresolvedImageSourceURL{Type: "preresolved", URL: i.url}}, nil
 }

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -26,11 +26,11 @@ func NewPreresolvedImage(url string, metas []config.ImageMeta) PreresolvedImage 
 
 func (i PreresolvedImage) URL() (string, []Meta, error) {
 	if len(i.metas) > 0 {
-		var givenMetas []Meta
+		var imageMetas []Meta
 		for _, m := range i.metas {
-			givenMetas = append(givenMetas, PreresolvedImageSourceURL{Type: "preresolved", URL: m.URL, Tag: m.Tag})
+			imageMetas = append(imageMetas, PreresolvedImageSourceURL{Type: "preresolved", URL: m.URL, Tag: m.Tag})
 		}
-		return i.url, givenMetas, nil
+		return i.url, imageMetas, nil
 	}
 	return i.url, []Meta{PreresolvedImageSourceURL{Type: "preresolved", URL: i.url}}, nil
 }

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -28,8 +28,7 @@ func (i PreresolvedImage) URL() (string, []Meta, error) {
 	if len(i.metas) > 0 {
 		var givenMetas []Meta
 		for _, m := range i.metas {
-			//TODO: should we change Type to 'preresolved' or keep whatever is given from lockfile?
-			givenMetas = append(givenMetas, PreresolvedImageSourceURL{Type: m.Type, URL: m.URL, Tag: m.Tag})
+			givenMetas = append(givenMetas, PreresolvedImageSourceURL{Type: "preresolved", URL: m.URL, Tag: m.Tag})
 		}
 		return i.url, givenMetas, nil
 	}

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -13,11 +13,16 @@ type PreresolvedImage struct {
 }
 
 func NewPreresolvedImage(url string, metas []ctlconf.Meta) PreresolvedImage {
-	return PreresolvedImage{url, metas}
+	return PreresolvedImage{url, copyAndAppendMeta(metas)}
 }
 
 func (i PreresolvedImage) URL() (string, []ctlconf.Meta, error) {
-	imageMetas := append(i.metas, ctlconf.PreresolvedImageSourceURL{Type: "preresolved", URL: i.url})
-
+	imageMetas := copyAndAppendMeta(i.metas, ctlconf.PreresolvedImageSourceURL{Type: ctlconf.PreresolvedMeta, URL: i.url})
 	return i.url, imageMetas, nil
+}
+
+func copyAndAppendMeta(existing []ctlconf.Meta, new ...ctlconf.Meta) []ctlconf.Meta {
+	all := make([]ctlconf.Meta, len(existing), len(existing)+len(new))
+	copy(all, existing)
+	return append(all, new...)
 }

--- a/pkg/kbld/image/resolved.go
+++ b/pkg/kbld/image/resolved.go
@@ -10,7 +10,7 @@ import (
 	ctlreg "github.com/k14s/kbld/pkg/kbld/registry"
 )
 
-// ResolvedImage respresents an image that will be resolved into url+digest
+// ResolvedImage represents an image that will be resolved into url+digest
 type ResolvedImage struct {
 	url      string
 	registry ctlreg.Registry

--- a/pkg/kbld/image/resolved.go
+++ b/pkg/kbld/image/resolved.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	regname "github.com/google/go-containerregistry/pkg/name"
+	ctlconf "github.com/k14s/kbld/pkg/kbld/config"
 	ctlreg "github.com/k14s/kbld/pkg/kbld/registry"
 )
 
@@ -16,19 +17,11 @@ type ResolvedImage struct {
 	registry ctlreg.Registry
 }
 
-type ResolvedImageSourceURL struct {
-	Type string // always set to 'resolved'
-	URL  string
-	Tag  string
-}
-
-func (ResolvedImageSourceURL) meta() {}
-
 func NewResolvedImage(url string, registry ctlreg.Registry) ResolvedImage {
 	return ResolvedImage{url, registry}
 }
 
-func (i ResolvedImage) URL() (string, []Meta, error) {
+func (i ResolvedImage) URL() (string, []ctlconf.Meta, error) {
 	tag, err := regname.NewTag(i.url, regname.WeakValidation)
 	if err != nil {
 		return "", nil, err
@@ -56,7 +49,7 @@ func (i ResolvedImage) URL() (string, []Meta, error) {
 		return "", nil, err
 	}
 
-	metas = append(metas, ResolvedImageSourceURL{Type: "resolved", URL: i.url, Tag: tag.TagStr()})
+	metas = append(metas, ctlconf.ResolvedImageSourceURL{Type: "resolved", URL: i.url, Tag: tag.TagStr()})
 
 	return url, metas, nil
 }

--- a/pkg/kbld/image/resolved.go
+++ b/pkg/kbld/image/resolved.go
@@ -49,7 +49,7 @@ func (i ResolvedImage) URL() (string, []ctlconf.Meta, error) {
 		return "", nil, err
 	}
 
-	metas = append(metas, ctlconf.ResolvedImageSourceURL{Type: "resolved", URL: i.url, Tag: tag.TagStr()})
+	metas = append(metas, ctlconf.ResolvedImageSourceURL{Type: ctlconf.ResolvedMeta, URL: i.url, Tag: tag.TagStr()})
 
 	return url, metas, nil
 }

--- a/pkg/kbld/image/tag_selected.go
+++ b/pkg/kbld/image/tag_selected.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	regname "github.com/google/go-containerregistry/pkg/name"
+	ctlconf "github.com/k14s/kbld/pkg/kbld/config"
 	ctlreg "github.com/k14s/kbld/pkg/kbld/registry"
 	versions "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1"
 )
@@ -24,7 +25,7 @@ func NewTagSelectedImage(url string, selection *versions.VersionSelection,
 	return TagSelectedImage{url, selection, registry}
 }
 
-func (i TagSelectedImage) URL() (string, []Meta, error) {
+func (i TagSelectedImage) URL() (string, []ctlconf.Meta, error) {
 	repo, err := regname.NewRepository(i.url, regname.WeakValidation)
 	if err != nil {
 		return "", nil, err

--- a/pkg/kbld/image/tag_selected.go
+++ b/pkg/kbld/image/tag_selected.go
@@ -11,7 +11,7 @@ import (
 	versions "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1"
 )
 
-// TagSelectedImage respresents an image that will be resolved into url+digest
+// TagSelectedImage represents an image that will be resolved into url+digest
 type TagSelectedImage struct {
 	url       string
 	selection *versions.VersionSelection

--- a/pkg/kbld/image/tagged.go
+++ b/pkg/kbld/image/tagged.go
@@ -46,7 +46,7 @@ func (i TaggedImage) URL() (string, []ctlconf.Meta, error) {
 			}
 		}
 
-		metas = append(metas, ctlconf.TaggedImageMeta{Type: "tagged", Tags: i.imgDst.Tags})
+		metas = append(metas, ctlconf.TaggedImageMeta{Type: ctlconf.TaggedMeta, Tags: i.imgDst.Tags})
 	}
 
 	return url, metas, err

--- a/pkg/kbld/image/tagged.go
+++ b/pkg/kbld/image/tagged.go
@@ -9,7 +9,7 @@ import (
 	ctlreg "github.com/k14s/kbld/pkg/kbld/registry"
 )
 
-// TaggedImage respresents an image that will be tagged when its URL is requested
+// TaggedImage represents an image that will be tagged when its URL is requested
 type TaggedImage struct {
 	image    Image
 	imgDst   ctlconf.ImageDestination

--- a/pkg/kbld/image/tagged.go
+++ b/pkg/kbld/image/tagged.go
@@ -16,18 +16,11 @@ type TaggedImage struct {
 	registry ctlreg.Registry
 }
 
-type TaggedImageMeta struct {
-	Type string // always set to 'tagged'
-	Tags []string
-}
-
-func (TaggedImageMeta) meta() {}
-
 func NewTaggedImage(image Image, imgDst ctlconf.ImageDestination, registry ctlreg.Registry) TaggedImage {
 	return TaggedImage{image, imgDst, registry}
 }
 
-func (i TaggedImage) URL() (string, []Meta, error) {
+func (i TaggedImage) URL() (string, []ctlconf.Meta, error) {
 	url, metas, err := i.image.URL()
 	if err != nil {
 		return "", nil, err
@@ -53,7 +46,7 @@ func (i TaggedImage) URL() (string, []Meta, error) {
 			}
 		}
 
-		metas = append(metas, TaggedImageMeta{Type: "tagged", Tags: i.imgDst.Tags})
+		metas = append(metas, ctlconf.TaggedImageMeta{Type: "tagged", Tags: i.imgDst.Tags})
 	}
 
 	return url, metas, err

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	imgLockWithMetas = `---
+	imgLockWithResolvedMetas = `---
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
@@ -30,7 +30,61 @@ images:
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `
-	imgLockNoMetas = `---
+	imgLockWithBuiltMetas = `---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: nginx:1.14.2
+    kbld.carvel.dev/metas: |
+      - Path: path/to/source
+        Type: local
+      - Dirty: true
+        RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+        SHA: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
+        Type: git
+  image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+- annotations:
+    kbld.carvel.dev/id: sample-app
+    kbld.carvel.dev/metas: |
+      - Path: path/to/source
+        Type: local
+      - Dirty: true
+        RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+        SHA: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
+        Type: git
+  image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+kind: ImagesLock
+`
+	imgLockWithBuiltAndPreresolvedMetas = `---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: nginx:1.14.2
+    kbld.carvel.dev/metas: |
+      - Path: path/to/source
+        Type: local
+      - Dirty: true
+        RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+        SHA: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
+        Type: git
+      - Type: preresolved
+        URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+  image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+- annotations:
+    kbld.carvel.dev/id: sample-app
+    kbld.carvel.dev/metas: |
+      - Path: path/to/source
+        Type: local
+      - Dirty: true
+        RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+        SHA: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
+        Type: git
+      - Type: preresolved
+        URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+  image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+kind: ImagesLock
+`
+	imgLock = `---
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
@@ -183,8 +237,8 @@ images:
 		t.Fatalf("Failed while reading " + path)
 	}
 
-	if string(bs) != imgLockWithMetas {
-		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLockWithMetas)
+	if string(bs) != imgLockWithResolvedMetas {
+		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLockWithResolvedMetas)
 	}
 }
 
@@ -192,7 +246,7 @@ func TestImgpkgLockFileNotInOutput(t *testing.T) {
 	env := BuildEnv(t)
 	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
 
-	input := imgLockWithMetas
+	input := imgLock
 	out, _ := kbld.RunWithOpts([]string{"-f", "-", "--images-annotation=false"}, RunOpts{
 		StdinReader: strings.NewReader(input),
 	})
@@ -212,33 +266,7 @@ images:
 - image: nginx:1.14.2
 - image: sample-app
 ---
-` + imgLockWithMetas
-
-	out, _ := kbld.RunWithOpts([]string{"-f", "-", "--images-annotation=false"}, RunOpts{
-		StdinReader: strings.NewReader(input),
-	})
-
-	expectedOut := `---
-images:
-- image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
-- image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
-`
-	if out != expectedOut {
-		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", out, expectedOut)
-	}
-
-}
-
-func TestImgpkgLockFileInputSuccessfulWithAnnotations(t *testing.T) {
-	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
-
-	input := `
-images:
-- image: nginx:1.14.2
-- image: sample-app
----
-` + imgLockWithMetas
+` + imgLockWithResolvedMetas
 
 	out, _ := kbld.RunWithOpts([]string{"-f", "-"}, RunOpts{
 		StdinReader: strings.NewReader(input),
@@ -271,7 +299,66 @@ metadata:
 	}
 }
 
-func TestImgpkgLockOutputSuccessfulOnDigestedImage(t *testing.T) {
+func TestImgpkgLockFileMetasSuccessful(t *testing.T) {
+	env := BuildEnv(t)
+	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+
+	input := `
+images:
+- image: nginx:1.14.2
+- image: sample-app
+---
+` + imgLockWithBuiltMetas
+
+	path := "/tmp/kbld-test-lock-metas"
+	defer os.RemoveAll(path)
+	out, _ := kbld.RunWithOpts([]string{"-f", "-", "--imgpkg-lock-output=" + path}, RunOpts{
+		StdinReader: strings.NewReader(input),
+	})
+
+	expectedOut := `---
+images:
+- image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+- image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Path: path/to/source
+          Type: local
+        - Dirty: true
+          RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+          SHA: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
+          Type: git
+        - Type: preresolved
+          URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+        URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+      - Metas:
+        - Path: path/to/source
+          Type: local
+        - Dirty: true
+          RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+          SHA: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
+          Type: git
+        - Type: preresolved
+          URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+        URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+`
+	if out != expectedOut {
+		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", out, expectedOut)
+	}
+
+	bs, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed while reading " + path)
+	}
+
+	if string(bs) != imgLockWithBuiltAndPreresolvedMetas {
+		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLockWithBuiltAndPreresolvedMetas)
+	}
+}
+
+func TestImgpkgLockOutputSuccessfulDigestedImageHasNoMetas(t *testing.T) {
 	env := BuildEnv(t)
 	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
 
@@ -302,7 +389,8 @@ images:
 		t.Fatalf("Failed while reading " + path)
 	}
 
-	if string(bs) != imgLockNoMetas {
-		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLockWithMetas)
+	// For Digest references, Image Lock should not have metas since there is no image metadata
+	if string(bs) != imgLock {
+		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLock)
 	}
 }

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -265,7 +265,6 @@ metadata:
 	if out != expectedOut {
 		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", out, expectedOut)
 	}
-
 }
 
 func TestImgpkgLockOutputSuccessfulOnDigestedImage(t *testing.T) {

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -234,7 +234,6 @@ images:
 	})
 
 	expectedOut := `---
----
 images:
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
@@ -243,12 +242,12 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Tag: 1.15.1
-          Type: resolved
+          Type: preresolved
           URL: nginx:1.15.1
         URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
       - Metas:
         - Tag: 1.14.2
-          Type: resolved
+          Type: preresolved
           URL: nginx:1.14.2
         URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 `

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -16,9 +16,17 @@ apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
+    kbld.carvel.dev/metas: |
+      - Tag: 1.14.2
+        Type: resolved
+        URL: nginx:1.14.2
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
+    kbld.carvel.dev/metas: |
+      - Tag: 1.15.1
+        Type: resolved
+        URL: nginx:1.15.1
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -18,14 +18,14 @@ images:
     kbld.carvel.dev/id: nginx:1.14.2
     kbld.carvel.dev/metas: |
       - Tag: 1.14.2
-        Type: preresolved
+        Type: resolved
         URL: nginx:1.14.2
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
     kbld.carvel.dev/metas: |
       - Tag: 1.15.1
-        Type: preresolved
+        Type: resolved
         URL: nginx:1.15.1
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
@@ -253,13 +253,17 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Tag: 1.15.1
-          Type: preresolved
+          Type: resolved
           URL: nginx:1.15.1
+        - Type: preresolved
+          URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
         URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
       - Metas:
         - Tag: 1.14.2
-          Type: preresolved
+          Type: resolved
           URL: nginx:1.14.2
+        - Type: preresolved
+          URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
         URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 `
 	if out != expectedOut {

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -217,3 +217,43 @@ images:
 	}
 
 }
+
+func TestImgpkgLockFileInputSuccessfulWithAnnotations(t *testing.T) {
+	env := BuildEnv(t)
+	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+
+	input := `
+images:
+- image: nginx:1.14.2
+- image: sample-app
+---
+` + imgLock
+
+	out, _ := kbld.RunWithOpts([]string{"-f", "-"}, RunOpts{
+		StdinReader: strings.NewReader(input),
+	})
+
+	expectedOut := `---
+---
+images:
+- image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+- image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.15.1
+          Type: resolved
+          URL: nginx:1.15.1
+        URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+      - Metas:
+        - Tag: 1.14.2
+          Type: resolved
+          URL: nginx:1.14.2
+        URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+`
+	if out != expectedOut {
+		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", out, expectedOut)
+	}
+
+}


### PR DESCRIPTION
**When using the `--imgpkg-lock-output` flag, this PR adds the ` kbld.carvel.dev/metas` annotation.**
```
images:
- annotations:
    kbld.carvel.dev/metas: |
      - Tag: x.x.x
        Type: resolved
        URL: image-name:x.x.x
```

**When using a lock file as input to kbld, this PR also will preserve any ` kbld.carvel.dev/metas`**. It will append new metas to the list in the output and an imgpkg Lock file. This results in a history for example:
```
images:
- annotations:
    kbld.carvel.dev/metas: |
      - Tag: x.x.x
        Type: resolved
        URL: image-name:x.x.x
      - Type: preresolved
        URL: index.docker.io/library/..@sha256:...
```

**Other new behavior**:
- If a ` kbld.carvel.dev/metas` annotation is malformatted, kbld will error.
- the ` kbld.carvel.dev/metas` annotation must be in the format of several predefined objects, other unknown meta objects will be ignored.