### PR TITLE
Fix failing tests in GitHub action

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   test-all:
     name: Test GH
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -31,15 +31,19 @@ jobs:
       run: |
         set -e -x
 
+        mkdir -p ~/.docker/machine/cache
+        curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
+        brew install docker docker-machine
+
         # Install ytt, kapp for build and tests
         mkdir -p /tmp/bin
         export PATH=/tmp/bin:$PATH
 
         wget -O- https://k14s.io/install.sh | K14SIO_INSTALL_BIN_DIR=/tmp/bin bash
 
-        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.10.0/minikube-linux-amd64 > /tmp/bin/minikube
+        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.10.0/minikube-darwin-amd64 > /tmp/bin/minikube
         chmod +x /tmp/bin/minikube
-        minikube start --driver=docker --insecure-registry=172.17.0.0/16
+        minikube start --driver=virtualbox --insecure-registry=192.168.99.100/16
         eval $(minikube docker-env --shell=bash)
 
         # Ensure that there is no existing kbld installed
@@ -48,16 +52,16 @@ jobs:
         git config --global user.email "dummy@k14s.io"
         git config --global user.name "Dummy dummy"
 
-        wget -O- https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl > /tmp/bin/kubectl
+        wget -O- https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/darwin/amd64/kubectl > /tmp/bin/kubectl
         chmod +x /tmp/bin/kubectl
 
-        wget -O- https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases/download/v0.1.0/linux-refs.tags.v0.1.0.tgz > /tmp/kb-cli.tgz
+        wget -O- https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases/download/v0.1.0/darwin-refs.tags.v0.1.0.tgz > /tmp/kb-cli.tgz
         tar xzvf /tmp/kb-cli.tgz -C /tmp/bin
 
-        wget -O- https://github.com/buildpacks/pack/releases/download/v0.8.1/pack-v0.8.1-linux.tgz > /tmp/pack-cli.tgz
+        wget -O- https://github.com/buildpacks/pack/releases/download/v0.8.1/pack-v0.8.1-macos.tgz > /tmp/pack-cli.tgz
         tar xzvf /tmp/pack-cli.tgz -C /tmp/bin
 
-        wget -O- https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz > /tmp/ko.tgz
+        wget -O- https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Darwin_x86_64.tar.gz > /tmp/ko.tgz
         tar xzvf /tmp/ko.tgz -C /tmp/bin
 
         cd "src/github.com/${{ github.repository }}"


### PR DESCRIPTION
Update GitHub action to use minikube virtualbox

- Fix failing tests by using virtualbox on macos since there were issues
  with ports on the docker driver