### PR TITLE
Add Bazel support

### DIFF
--- a/examples/simple-app-build-local-bazel/build.yml
+++ b/examples/simple-app-build-local-bazel/build.yml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kbld-simple-app-build-local-bazel
+spec:
+  selector:
+    matchLabels:
+      app: kbld-simple-app-build-local-bazel
+  template:
+    metadata:
+      labels:
+        app: kbld-simple-app-build-local-bazel
+    spec:
+      containers:
+      - name: my-app
+        image: simple-app
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+- image: simple-app
+  path: test/e2e/assets/simple-app
+  bazel:
+    build:
+      label: :simple-app

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -17,6 +17,11 @@ if [ "$(ko version)" != "0.8.0" ]; then
   exit 1
 fi
 
+if [ "$(bazel --version | grep -o '4.2.0')" != "4.2.0" ]; then
+    echo "Please install 'bazel' from https://github.com/bazelbuild/bazel/releases/tag/4.2.0"
+    exit 1
+fi
+
 go clean -testcache
 
 export KBLD_BINARY_PATH="${KBLD_BINARY_PATH:-$PWD/kbld}"

--- a/pkg/kbld/builder/bazel/bazel.go
+++ b/pkg/kbld/builder/bazel/bazel.go
@@ -1,0 +1,75 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+
+	ctlbdk "github.com/k14s/kbld/pkg/kbld/builder/docker"
+	"github.com/k14s/kbld/pkg/kbld/config"
+	ctllog "github.com/k14s/kbld/pkg/kbld/logger"
+)
+
+var (
+	bazelImageID = regexp.MustCompile("Loaded image ID: (sha256:)?([0-9a-z]+)")
+)
+
+type Bazel struct {
+	docker ctlbdk.Docker
+	logger ctllog.Logger
+}
+
+func NewBazel(docker ctlbdk.Docker, logger ctllog.Logger) Bazel {
+	return Bazel{docker: docker, logger: logger}
+}
+
+func (b *Bazel) Build(image, directory string, opts config.SourceBazelBuildOpts) (ctlbdk.DockerTmpRef, error) {
+
+	prefixedLogger := b.logger.NewPrefixedWriter(image + " | ")
+
+	prefixedLogger.Write([]byte(fmt.Sprintf("starting build (using bazel): %s\n", directory)))
+	defer prefixedLogger.Write([]byte("finished build (using bazel)\n"))
+
+	var imageID string
+	{
+		var stdoutBuf, stderrBuf bytes.Buffer
+
+		if opts.Label == nil {
+			return ctlbdk.DockerTmpRef{}, fmt.Errorf("Expected label to be specified, but was not")
+		}
+
+		cmdArgs := []string{"run"}
+
+		if opts.Label != nil {
+			cmdArgs = append(cmdArgs, *opts.Label)
+		}
+		if opts.RawOptions != nil {
+			cmdArgs = append(cmdArgs, *opts.RawOptions...)
+		}
+
+		cmd := exec.Command("bazel", cmdArgs...)
+		cmd.Dir = directory
+		cmd.Stdout = io.MultiWriter(&stdoutBuf, prefixedLogger)
+		cmd.Stderr = io.MultiWriter(&stderrBuf, prefixedLogger)
+
+		err := cmd.Run()
+		if err != nil {
+			prefixedLogger.Write([]byte(fmt.Sprintf("error: %s\n", err)))
+			return ctlbdk.DockerTmpRef{}, err
+		}
+
+		matches := bazelImageID.FindStringSubmatch(stdoutBuf.String())
+		if len(matches) != 3 {
+			return ctlbdk.DockerTmpRef{}, fmt.Errorf("Expected to find image ID in bazel output but did not")
+		}
+
+		imageID = "sha256:" + matches[2]
+	}
+
+	return b.docker.RetagStable(ctlbdk.NewDockerTmpRef(imageID), image, imageID, prefixedLogger)
+}

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -60,6 +60,7 @@ type Source struct {
 	Pack            *SourcePackOpts
 	KubectlBuildkit *SourceKubectlBuildkitOpts
 	Ko              *SourceKoOpts
+	Bazel           *SourceBazelOpts
 }
 
 type ImageOverride struct {

--- a/pkg/kbld/config/config_bazel.go
+++ b/pkg/kbld/config/config_bazel.go
@@ -1,0 +1,10 @@
+package config
+
+type SourceBazelOpts struct {
+	Build SourceBazelBuildOpts
+}
+
+type SourceBazelBuildOpts struct {
+	Label      *string   `json:"label"`
+	RawOptions *[]string `json:"rawOptions"`
+}

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -6,6 +6,7 @@ package image
 import (
 	"path/filepath"
 
+	ctlbbz "github.com/k14s/kbld/pkg/kbld/builder/bazel"
 	ctlbdk "github.com/k14s/kbld/pkg/kbld/builder/docker"
 	ctlbko "github.com/k14s/kbld/pkg/kbld/builder/ko"
 	ctlbkb "github.com/k14s/kbld/pkg/kbld/builder/kubectlbuildkit"
@@ -22,12 +23,13 @@ type BuiltImage struct {
 	pack            ctlbpk.Pack
 	kubectlBuildkit ctlbkb.KubectlBuildkit
 	ko              ctlbko.Ko
+	bazel           ctlbbz.Bazel
 }
 
 func NewBuiltImage(url string, buildSource ctlconf.Source, imgDst *ctlconf.ImageDestination,
-	docker ctlbdk.Docker, pack ctlbpk.Pack, kubectlBuildkit ctlbkb.KubectlBuildkit, ko ctlbko.Ko) BuiltImage {
+	docker ctlbdk.Docker, pack ctlbpk.Pack, kubectlBuildkit ctlbkb.KubectlBuildkit, ko ctlbko.Ko, bazel ctlbbz.Bazel) BuiltImage {
 
-	return BuiltImage{url, buildSource, imgDst, docker, pack, kubectlBuildkit, ko}
+	return BuiltImage{url, buildSource, imgDst, docker, pack, kubectlBuildkit, ko, bazel}
 }
 
 func (i BuiltImage) URL() (string, []Meta, error) {
@@ -61,6 +63,14 @@ func (i BuiltImage) URL() (string, []Meta, error) {
 
 	case i.buildSource.Ko != nil:
 		dockerTmpRef, err := i.ko.Build(urlRepo, i.buildSource.Path, i.buildSource.Ko.Build)
+		if err != nil {
+			return "", nil, err
+		}
+
+		return i.optionalPushWithDocker(dockerTmpRef, metas)
+
+	case i.buildSource.Bazel != nil:
+		dockerTmpRef, err := i.bazel.Build(urlRepo, i.buildSource.Path, i.buildSource.Bazel.Build)
 		if err != nil {
 			return "", nil, err
 		}

--- a/pkg/kbld/image/factory.go
+++ b/pkg/kbld/image/factory.go
@@ -4,6 +4,7 @@
 package image
 
 import (
+	ctlbbz "github.com/k14s/kbld/pkg/kbld/builder/bazel"
 	ctlbdk "github.com/k14s/kbld/pkg/kbld/builder/docker"
 	ctlbko "github.com/k14s/kbld/pkg/kbld/builder/ko"
 	ctlbkb "github.com/k14s/kbld/pkg/kbld/builder/kubectlbuildkit"
@@ -48,9 +49,10 @@ func (f Factory) New(url string) Image {
 		pack := ctlbpk.NewPack(docker, f.logger)
 		kubectlBuildkit := ctlbkb.NewKubectlBuildkit(f.logger)
 		ko := ctlbko.NewKo(f.logger)
+		bazel := ctlbbz.NewBazel(docker, f.logger)
 
 		builtImg := NewBuiltImage(url, srcConf, imgDstConf,
-			docker, pack, kubectlBuildkit, ko)
+			docker, pack, kubectlBuildkit, ko, bazel)
 
 		if imgDstConf != nil {
 			return NewTaggedImage(builtImg, *imgDstConf, f.registry)

--- a/test/e2e/assets/simple-app/BUILD.bazel
+++ b/test/e2e/assets/simple-app/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+package(default_visibility = ["//visibility:public"])
+
+go_image(
+    name = "simple-app-go-image",
+    srcs = ["app.go"],
+    importpath = "github.com/carvel-kbld/test/e2e/assets/simple-app",
+)
+
+container_image(
+    name = "simple-app",
+    base = ":simple-app-go-image",
+)

--- a/test/e2e/assets/simple-app/WORKSPACE
+++ b/test/e2e/assets/simple-app/WORKSPACE
@@ -1,0 +1,33 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "08369b54a7cbe9348eea474e36c9bbb19d47101e8860cec75cbf1ccd4f749281",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.0/rules_go-v0.24.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.0/rules_go-v0.24.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+go_rules_dependencies()
+go_register_toolchains()
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "59d5b42ac315e7eadffa944e86e90c2990110a1c8075f1cd145f487e999d22b3",
+    strip_prefix = "rules_docker-0.17.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.17.0/rules_docker-v0.17.0.tar.gz"],
+)
+
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+container_repositories()
+
+load(
+    "@io_bazel_rules_docker//go:image.bzl",
+    _go_image_repos = "repositories",
+)
+_go_image_repos()

--- a/test/e2e/build_bazel_test.go
+++ b/test/e2e/build_bazel_test.go
@@ -1,0 +1,58 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestBazelBuildAndPushSuccessful(t *testing.T) {
+	env := BuildEnv(t)
+	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	input := env.WithRegistries(`
+kind: Object
+spec:
+- image: docker.io/*username*/kbld-e2e-tests-build
+- image: docker.io/*username*/kbld-e2e-tests-build2
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Sources
+sources:
+- image: docker.io/*username*/kbld-e2e-tests-build
+  path: assets/simple-app
+  bazel:
+    build:
+      label: :simple-app
+- image: docker.io/*username*/kbld-e2e-tests-build2
+  path: assets/simple-app
+  bazel:
+    build:
+      label: :simple-app
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: ImageDestinations
+destinations:
+- image: docker.io/*username*/kbld-e2e-tests-build
+- image: docker.io/*username*/kbld-e2e-tests-build2
+`)
+
+	out, _ := kbld.RunWithOpts([]string{"-f", "-", "--images-annotation=false"}, RunOpts{
+		StdinReader: strings.NewReader(input),
+	})
+
+	out = strings.Replace(out, regexp.MustCompile("sha256:[a-z0-9]{64}").FindString(out), "SHA256-REPLACED", -1)
+
+	expectedOut := env.WithRegistries(`---
+kind: Object
+spec:
+- image: index.docker.io/*username*/kbld-e2e-tests-build@SHA256-REPLACED
+- image: index.docker.io/*username*/kbld-e2e-tests-build2@SHA256-REPLACED
+`)
+
+	if out != expectedOut {
+		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", out, expectedOut)
+	}
+}


### PR DESCRIPTION
Implements option 2 stated in: https://github.com/vmware-tanzu/carvel-kbld/issues/128.

The implementation is similar to the other builders. `bazel run <label>` is used for the sub process command as it outputs the image digest if `container_image(...)` is used. 

One thing to note about `bazel run <label>` is that it isn't limited to just image building, but can also run tests and binaries (depending on how its configured). Thus it is recommended that the label used for `label` has `container_image(...)` as the last step in the `BUILD.bazel`.