### PR TITLE
Add DockerHub credentials to E2E in CI

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -55,11 +55,11 @@ jobs:
         # ... for builders using Docker
         echo "${DOCKERHUB_ACCESS_TOKEN}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
         # ... for kubectl-buildkit
-        kubectl create secret docker-registry buildkit \
+        minikube kubectl --ssh=true -- create secret docker-registry buildkit \
           --docker-username="${DOCKERHUB_USERNAME}" \
           --docker-password="${DOCKERHUB_ACCESS_TOKEN}"
         # ... for any other service account that pulls images from DockerHub
-        kubectl create secret docker-registry dockerhub-credentials \
+        minikube kubectl --ssh=true -- create secret docker-registry dockerhub-credentials \
           --docker-username="${DOCKERHUB_USERNAME}" \
           --docker-password="${DOCKERHUB_ACCESS_TOKEN}"
 

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -37,7 +37,8 @@ jobs:
         set -e -x
 
         mkdir -p ~/.docker/machine/cache
-        curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
+        wget -O -nv https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso > ~/.docker/machine/cache/boot2docker.iso
+
         brew install docker docker-machine
 
         # Install ytt, kapp for build and tests
@@ -65,9 +66,6 @@ jobs:
 
         # Ensure that there is no existing kbld installed
         rm -f /tmp/bin/kbld
-
-        git config --global user.email "dummy@k14s.io"
-        git config --global user.name "Dummy dummy"
 
         wget -O- -nv https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/darwin/amd64/kubectl > /tmp/bin/kubectl
         chmod +x /tmp/bin/kubectl

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -37,7 +37,7 @@ jobs:
         set -e -x
 
         mkdir -p ~/.docker/machine/cache
-        wget -O -nv https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso > ~/.docker/machine/cache/boot2docker.iso
+        wget -O- -nv https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso > ~/.docker/machine/cache/boot2docker.iso
 
         brew install docker docker-machine
 

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -18,6 +18,7 @@ jobs:
   test-all:
     name: Test GH
     runs-on: macos-latest
+    environment: DockerHub E2E
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -29,6 +30,9 @@ jobs:
         path: src/github.com/${{ github.repository }}
         fetch-depth: 0
     - name: Run Tests
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       run: |
         set -e -x
 
@@ -46,6 +50,18 @@ jobs:
         chmod +x /tmp/bin/minikube
         minikube start --driver=virtualbox --insecure-registry=192.168.99.100/16
         eval $(minikube docker-env --shell=bash)
+
+        # Authenticate to DockerHub to avoid test failures due to rate limiting
+        # ... for builders using Docker
+        echo "${DOCKERHUB_ACCESS_TOKEN}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+        # ... for kubectl-buildkit
+        kubectl create secret docker-registry buildkit \
+          --docker-username="${DOCKERHUB_USERNAME}" \
+          --docker-password="${DOCKERHUB_ACCESS_TOKEN}"
+        # ... for any other service account that pulls images from DockerHub
+        kubectl create secret docker-registry dockerhub-credentials \
+          --docker-username="${DOCKERHUB_USERNAME}" \
+          --docker-password="${DOCKERHUB_ACCESS_TOKEN}"
 
         # Ensure that there is no existing kbld installed
         rm -f /tmp/bin/kbld

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -46,7 +46,7 @@ jobs:
 
         wget -O- https://k14s.io/install.sh | K14SIO_INSTALL_BIN_DIR=/tmp/bin bash
 
-        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.10.0/minikube-darwin-amd64 > /tmp/bin/minikube
+        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.22.0/minikube-darwin-amd64 > /tmp/bin/minikube
         chmod +x /tmp/bin/minikube
         minikube start --driver=virtualbox --insecure-registry=192.168.99.100/16
         eval $(minikube docker-env --shell=bash)

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
     - name: Run Tests
       env:
-        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_USERNAME: k8slt
         DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       run: |
         set -e -x

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -44,11 +44,11 @@ jobs:
         mkdir -p /tmp/bin
         export PATH=/tmp/bin:$PATH
 
-        wget -O- https://k14s.io/install.sh | K14SIO_INSTALL_BIN_DIR=/tmp/bin bash
+        wget -O- -nv https://k14s.io/install.sh | K14SIO_INSTALL_BIN_DIR=/tmp/bin bash
 
-        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.22.0/minikube-darwin-amd64 > /tmp/bin/minikube
+        wget -O- -nv https://github.com/kubernetes/minikube/releases/download/v1.22.0/minikube-darwin-amd64 > /tmp/bin/minikube
         chmod +x /tmp/bin/minikube
-        minikube start --driver=virtualbox --insecure-registry=192.168.99.100/16
+        minikube start --driver=virtualbox --insecure-registry=192.168.0.0/16
         eval $(minikube docker-env --shell=bash)
 
         # Authenticate to DockerHub to avoid test failures due to rate limiting
@@ -69,16 +69,16 @@ jobs:
         git config --global user.email "dummy@k14s.io"
         git config --global user.name "Dummy dummy"
 
-        wget -O- https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/darwin/amd64/kubectl > /tmp/bin/kubectl
+        wget -O- -nv https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/darwin/amd64/kubectl > /tmp/bin/kubectl
         chmod +x /tmp/bin/kubectl
 
-        wget -O- https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases/download/v0.1.0/darwin-refs.tags.v0.1.0.tgz > /tmp/kb-cli.tgz
+        wget -O- -nv https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases/download/v0.1.0/darwin-refs.tags.v0.1.0.tgz > /tmp/kb-cli.tgz
         tar xzvf /tmp/kb-cli.tgz -C /tmp/bin
 
-        wget -O- https://github.com/buildpacks/pack/releases/download/v0.8.1/pack-v0.8.1-macos.tgz > /tmp/pack-cli.tgz
+        wget -O- -nv https://github.com/buildpacks/pack/releases/download/v0.8.1/pack-v0.8.1-macos.tgz > /tmp/pack-cli.tgz
         tar xzvf /tmp/pack-cli.tgz -C /tmp/bin
 
-        wget -O- https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Darwin_x86_64.tar.gz > /tmp/ko.tgz
+        wget -O- -nv https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Darwin_x86_64.tar.gz > /tmp/ko.tgz
         tar xzvf /tmp/ko.tgz -C /tmp/bin
 
         cd "src/github.com/${{ github.repository }}"

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -47,7 +47,7 @@ jobs:
 
         wget -O- -nv https://k14s.io/install.sh | K14SIO_INSTALL_BIN_DIR=/tmp/bin bash
 
-        wget -O- -nv https://github.com/kubernetes/minikube/releases/download/v1.22.0/minikube-darwin-amd64 > /tmp/bin/minikube
+        wget -O- -nv https://github.com/kubernetes/minikube/releases/latest/download/minikube-darwin-amd64 > /tmp/bin/minikube
         chmod +x /tmp/bin/minikube
         minikube start --driver=virtualbox --insecure-registry=192.168.0.0/16
         eval $(minikube docker-env --shell=bash)

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -54,15 +54,17 @@ jobs:
 
         # Authenticate to DockerHub to avoid test failures due to rate limiting
         # ... for builders using Docker
-        echo "${DOCKERHUB_ACCESS_TOKEN}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
-        # ... for kubectl-buildkit
-        minikube kubectl --ssh=true -- create secret docker-registry buildkit \
-          --docker-username="${DOCKERHUB_USERNAME}" \
-          --docker-password="${DOCKERHUB_ACCESS_TOKEN}"
-        # ... for any other service account that pulls images from DockerHub
-        minikube kubectl --ssh=true -- create secret docker-registry dockerhub-credentials \
-          --docker-username="${DOCKERHUB_USERNAME}" \
-          --docker-password="${DOCKERHUB_ACCESS_TOKEN}"
+        set +x
+          echo "${DOCKERHUB_ACCESS_TOKEN}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+          # ... for kubectl-buildkit
+          minikube kubectl --ssh=true -- create secret docker-registry buildkit \
+            --docker-username="${DOCKERHUB_USERNAME}" \
+            --docker-password="${DOCKERHUB_ACCESS_TOKEN}"
+          # ... for any other service account that pulls images from DockerHub
+          minikube kubectl --ssh=true -- create secret docker-registry dockerhub-credentials \
+            --docker-username="${DOCKERHUB_USERNAME}" \
+            --docker-password="${DOCKERHUB_ACCESS_TOKEN}"
+        set -x
 
         # Ensure that there is no existing kbld installed
         rm -f /tmp/bin/kbld

--- a/test/e2e/assets/minikube-local-registry.yml
+++ b/test/e2e/assets/minikube-local-registry.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: registry-sa
+imagePullSecrets:
+- name: dockerhub-credentials
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
In order to avoid rate limiting errors, uses injected credentials:
- authenticate the docker client;
- authenticate image pulls for Pods deployed as part of the test (today, just the `registry2`);
- provide credentials for kubectl-buildkit.

Includes minor improvements:
- reduce output from `wget` calls to reduce that noise
- remove some dead lines
- resolves #146

