### PR TITLE
Reorganize "meta" fields

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -9,7 +9,6 @@ VERSION="${1:-$LATEST_GIT_TAG}"
 export CGO_ENABLED=0
 LDFLAGS="-X github.com/k14s/kbld/pkg/kbld/version.Version=$VERSION -buildid="
 
-
 go fmt ./cmd/... ./pkg/... ./test/...
 go mod vendor
 go mod tidy
@@ -17,5 +16,8 @@ go mod tidy
 # export GOOS=linux GOARCH=amd64
 go build -ldflags="$LDFLAGS" -trimpath -o kbld ./cmd/kbld/...
 ./kbld version
+
+# compile tests, but do not run them: https://github.com/golang/go/issues/15513#issuecomment-839126426
+go test --exec=echo ./... >/dev/null
 
 echo "Success"

--- a/pkg/kbld/cmd/image.go
+++ b/pkg/kbld/cmd/image.go
@@ -39,8 +39,8 @@ func (i Image) Description() string {
 }
 
 type imageStruct struct {
-	URL   string
-	Metas []interface{}
+	URL   string        `json:"url"`
+	Metas []interface{} `json:"metas,omitempty"`
 }
 
 func (st imageStruct) equal(other imageStruct) bool {

--- a/pkg/kbld/config/image_meta.go
+++ b/pkg/kbld/config/image_meta.go
@@ -14,7 +14,7 @@ type Meta interface {
 }
 
 type imageMeta struct {
-	Metas []Meta
+	Metas []Meta `json:"metas,omitempty"`
 }
 
 const (
@@ -26,33 +26,33 @@ const (
 )
 
 type BuiltImageSourceGit struct {
-	Type      string // always set to GitMeta
-	RemoteURL string `json:",omitempty" yaml:",omitempty"`
-	SHA       string
-	Dirty     bool
-	Tags      []string `json:",omitempty" yaml:",omitempty"`
+	Type      string   `json:"type"` // always set to GitMeta
+	RemoteURL string   `json:"remoteUrl"`
+	SHA       string   `json:"sha"`
+	Dirty     bool     `json:"dirty"`
+	Tags      []string `json:"tags,omitempty"`
 }
 
 type BuiltImageSourceLocal struct {
-	Type string // always set to LocalMeta
-	Path string
+	Type string `json:"type"` // always set to LocalMeta
+	Path string `json:"path"`
 }
 
 type ResolvedImageSourceURL struct {
-	Type string // always set to ResolvedMeta
-	URL  string
-	Tag  string
+	Type string `json:"type"` // always set to ResolvedMeta
+	URL  string `json:"url"`
+	Tag  string `json:"tag,omitempty"`
 }
 
 type TaggedImageMeta struct {
-	Type string // always set to TaggedMeta
-	Tags []string
+	Type string   `json:"type"` // always set to TaggedMeta
+	Tags []string `json:"tags"`
 }
 
 type PreresolvedImageSourceURL struct {
-	Type string // always set to PreresolvedMeta
-	URL  string
-	Tag  string `json:",omitempty" yaml:",omitempty"`
+	Type string `json:"type"` // always set to PreresolvedMeta
+	URL  string `json:"url"`
+	Tag  string `json:"tag,omitempty"`
 }
 
 func (BuiltImageSourceGit) meta()       {}

--- a/pkg/kbld/config/image_meta.go
+++ b/pkg/kbld/config/image_meta.go
@@ -4,144 +4,62 @@
 package config
 
 import (
-	"encoding/json"
-
 	"sigs.k8s.io/yaml"
 )
 
-type Meta interface {
-	meta()
+type Meta struct {
+	Git         *MetaGit         `json:"git,omitempty"`
+	Local       *MetaLocal       `json:"local,omitempty"`
+	Resolved    *MetaResolved    `json:"resolved,omitempty"`
+	Tagged      *MetaTagged      `json:"tagged,omitempty"`
+	Preresolved *MetaPreresolved `json:"preresolved,omitempty"`
 }
 
-type imageMeta struct {
-	Metas []Meta `json:"metas,omitempty"`
+type MetaGit struct {
+	RemoteURL string   `json:"remoteURL"`
+	SHA       string   `json:"sha"`
+	Dirty     bool     `json:"dirty"`
+	Tags      []string `json:"tags,omitempty"`
 }
 
-type BuiltImageSourceGit struct {
-	Details struct {
-		RemoteURL string   `json:"remoteURL"`
-		SHA       string   `json:"sha"`
-		Dirty     bool     `json:"dirty"`
-		Tags      []string `json:"tags,omitempty"`
-	} `json:"git"`
+type MetaLocal struct {
+	Path string `json:"path"`
 }
 
-func NewBuiltImageSourceGit(sha string) *BuiltImageSourceGit {
-	newSource := &BuiltImageSourceGit{}
-	newSource.Details.SHA = sha
-	return newSource
+type MetaResolved struct {
+	URL string `json:"url"`
+	Tag string `json:"tag,omitempty"`
 }
 
-type BuiltImageSourceLocal struct {
-	Details struct {
-		Path string `json:"path"`
-	} `json:"local"`
+type MetaTagged struct {
+	Tags []string `json:"tags"`
 }
 
-func NewBuiltImageSourceLocal(path string) *BuiltImageSourceLocal {
-	newSource := &BuiltImageSourceLocal{}
-	newSource.Details.Path = path
-	return newSource
+type MetaPreresolved struct {
+	URL string `json:"url"`
+	Tag string `json:"tag,omitempty"`
 }
 
-type ResolvedImageSourceURL struct {
-	Details struct {
-		URL string `json:"url"`
-		Tag string `json:"tag,omitempty"`
-	} `json:"resolved"`
-}
+func NewMetasFromString(str string) ([]Meta, error) {
+	var metas []Meta
 
-func NewResolvedImageSourceURL(url string) *ResolvedImageSourceURL {
-	newSource := &ResolvedImageSourceURL{}
-	newSource.Details.URL = url
-	return newSource
-}
-
-type TaggedImageMeta struct {
-	Details struct {
-		Tags []string `json:"tags"`
-	} `json:"tagged"`
-}
-
-func NewTaggedImageMeta(tags []string) *TaggedImageMeta {
-	newSource := &TaggedImageMeta{}
-	newSource.Details.Tags = tags
-	return newSource
-}
-
-type PreresolvedImageSourceURL struct {
-	Details struct {
-		URL string `json:"url"`
-		Tag string `json:"tag,omitempty"`
-	} `json:"preresolved"`
-}
-
-func NewPreresolvedImageSourceURL(url string) *PreresolvedImageSourceURL {
-	newSource := &PreresolvedImageSourceURL{}
-	newSource.Details.URL = url
-	return newSource
-}
-
-func (BuiltImageSourceGit) meta()       {}
-func (BuiltImageSourceLocal) meta()     {}
-func (ResolvedImageSourceURL) meta()    {}
-func (TaggedImageMeta) meta()           {}
-func (PreresolvedImageSourceURL) meta() {}
-
-func NewMetasFromString(metas string) ([]Meta, error) {
-	imgMeta := imageMeta{}
-	err := yaml.Unmarshal([]byte(metas), &imgMeta)
+	// Ignores unknown types of meta. At this time...
+	// - "Meta" are provided as primarily optional diagnostic information
+	//   rather than operational data (read: less important). Losing
+	//   this information does not change the correctness of kbld's
+	//   primary purpose during deployment: to rewrite image references.
+	//   It would be more than an annoyance to error-out if we were
+	//   unable to parse such data.
+	// - Ideally, yes, we'd at least report a warning. However, if there's
+	//   a systemic condition (e.g. using an older version of kbld to
+	//   deploy than was used to package) there would likely be a flurry
+	//   of warnings. So, the feature would quickly need an enhancement
+	//   to de-dup such warnings. (read: added complexity)
+	// see also https://github.com/vmware-tanzu/carvel-kbld/issues/160
+	err := yaml.Unmarshal([]byte(str), &metas)
 	if err != nil {
 		return []Meta{}, err
 	}
-	return imgMeta.Metas, nil
-}
 
-var _ json.Unmarshaler = &imageMeta{}
-
-func (m *imageMeta) UnmarshalJSON(data []byte) error {
-	var list []interface{}
-	err := yaml.Unmarshal(data, &list)
-	if err != nil {
-		return err
-	}
-
-	for _, item := range list {
-		var local BuiltImageSourceLocal
-		var git BuiltImageSourceGit
-		var res ResolvedImageSourceURL
-		var preres PreresolvedImageSourceURL
-		var tag TaggedImageMeta
-
-		yamlItem, _ := yaml.Marshal(&item)
-
-		switch {
-		case yaml.Unmarshal(yamlItem, &local) == nil && local.Details.Path != "":
-			m.Metas = append(m.Metas, local)
-		case yaml.Unmarshal(yamlItem, &git) == nil && git.Details.SHA != "":
-			m.Metas = append(m.Metas, git)
-		case yaml.Unmarshal(yamlItem, &res) == nil && res.Details.URL != "":
-			m.Metas = append(m.Metas, res)
-		case yaml.Unmarshal(yamlItem, &preres) == nil && preres.Details.URL != "":
-			m.Metas = append(m.Metas, preres)
-		case yaml.Unmarshal(yamlItem, &tag) == nil && len(tag.Details.Tags) > 0:
-			m.Metas = append(m.Metas, tag)
-		default:
-			// ignore unknown meta.
-			// At this time...
-			// - "Meta" are provided as primarily optional diagnostic information
-			//   rather than operational data (read: less important). Losing
-			//   this information does not change the correctness of kbld's
-			//   primary purpose during deployment: to rewrite image references.
-			//   It would be more than an annoyance to error-out if we were
-			//   unable to parse such data.
-			// - Ideally, yes, we'd at least report a warning. However, if there's
-			//   a systemic condition (e.g. using an older version of kbld to
-			//   deploy than was used to package) there would likely be a flurry
-			//   of warnings. So, the feature would quickly need an enhancement
-			//   to de-dup such warnings. (read: added complexity)
-			// see also https://github.com/vmware-tanzu/carvel-kbld/issues/160
-		}
-	}
-	return nil
+	return metas, nil
 }

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -126,7 +126,7 @@ func (i BuiltImage) sources() ([]ctlconf.Meta, error) {
 		return nil, err
 	}
 
-	sources = append(sources, ctlconf.NewBuiltImageSourceLocal(absPath))
+	sources = append(sources, ctlconf.Meta{Local: &ctlconf.MetaLocal{Path: absPath}})
 
 	gitRepo := NewGitRepo(absPath)
 
@@ -138,24 +138,24 @@ func (i BuiltImage) sources() ([]ctlconf.Meta, error) {
 			return nil, err
 		}
 
-		git := ctlconf.NewBuiltImageSourceGit(sha)
+		git := ctlconf.MetaGit{SHA: sha}
 
-		git.Details.RemoteURL, err = gitRepo.RemoteURL()
+		git.RemoteURL, err = gitRepo.RemoteURL()
 		if err != nil {
 			return nil, err
 		}
 
-		git.Details.Dirty, err = gitRepo.IsDirty()
+		git.Dirty, err = gitRepo.IsDirty()
 		if err != nil {
 			return nil, err
 		}
 
-		git.Details.Tags, err = gitRepo.HeadTags()
+		git.Tags, err = gitRepo.HeadTags()
 		if err != nil {
 			return nil, err
 		}
 
-		sources = append(sources, git)
+		sources = append(sources, ctlconf.Meta{Git: &git})
 	}
 
 	return sources, nil

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -126,33 +126,31 @@ func (i BuiltImage) sources() ([]ctlconf.Meta, error) {
 		return nil, err
 	}
 
-	sources = append(sources, ctlconf.BuiltImageSourceLocal{
-		Type: ctlconf.LocalMeta,
-		Path: absPath,
-	})
+	sources = append(sources, ctlconf.NewBuiltImageSourceLocal(absPath))
 
 	gitRepo := NewGitRepo(absPath)
 
 	if gitRepo.IsValid() {
 		var err error
-		git := ctlconf.BuiltImageSourceGit{Type: ctlconf.GitMeta}
 
-		git.RemoteURL, err = gitRepo.RemoteURL()
+		sha, err := gitRepo.HeadSHA()
 		if err != nil {
 			return nil, err
 		}
 
-		git.SHA, err = gitRepo.HeadSHA()
+		git := ctlconf.NewBuiltImageSourceGit(sha)
+
+		git.Details.RemoteURL, err = gitRepo.RemoteURL()
 		if err != nil {
 			return nil, err
 		}
 
-		git.Dirty, err = gitRepo.IsDirty()
+		git.Details.Dirty, err = gitRepo.IsDirty()
 		if err != nil {
 			return nil, err
 		}
 
-		git.Tags, err = gitRepo.HeadTags()
+		git.Details.Tags, err = gitRepo.HeadTags()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -17,7 +17,7 @@ func NewPreresolvedImage(url string, metas []ctlconf.Meta) PreresolvedImage {
 }
 
 func (i PreresolvedImage) URL() (string, []ctlconf.Meta, error) {
-	imageMetas := copyAndAppendMeta(i.metas, ctlconf.NewPreresolvedImageSourceURL(i.url))
+	imageMetas := copyAndAppendMeta(i.metas, ctlconf.Meta{Preresolved: &ctlconf.MetaPreresolved{URL: i.url}})
 	return i.url, imageMetas, nil
 }
 

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -17,7 +17,7 @@ func NewPreresolvedImage(url string, metas []ctlconf.Meta) PreresolvedImage {
 }
 
 func (i PreresolvedImage) URL() (string, []ctlconf.Meta, error) {
-	imageMetas := copyAndAppendMeta(i.metas, ctlconf.PreresolvedImageSourceURL{Type: ctlconf.PreresolvedMeta, URL: i.url})
+	imageMetas := copyAndAppendMeta(i.metas, ctlconf.NewPreresolvedImageSourceURL(i.url))
 	return i.url, imageMetas, nil
 }
 

--- a/pkg/kbld/image/resolved.go
+++ b/pkg/kbld/image/resolved.go
@@ -49,9 +49,7 @@ func (i ResolvedImage) URL() (string, []ctlconf.Meta, error) {
 		return "", nil, err
 	}
 
-	resolvedSource := ctlconf.NewResolvedImageSourceURL(i.url)
-	resolvedSource.Details.Tag = tag.TagStr()
-	metas = append(metas, resolvedSource)
+	metas = append(metas, ctlconf.Meta{Resolved: &ctlconf.MetaResolved{URL: i.url, Tag: tag.TagStr()}})
 
 	return url, metas, nil
 }

--- a/pkg/kbld/image/resolved.go
+++ b/pkg/kbld/image/resolved.go
@@ -49,7 +49,9 @@ func (i ResolvedImage) URL() (string, []ctlconf.Meta, error) {
 		return "", nil, err
 	}
 
-	metas = append(metas, ctlconf.ResolvedImageSourceURL{Type: ctlconf.ResolvedMeta, URL: i.url, Tag: tag.TagStr()})
+	resolvedSource := ctlconf.NewResolvedImageSourceURL(i.url)
+	resolvedSource.Details.Tag = tag.TagStr()
+	metas = append(metas, resolvedSource)
 
 	return url, metas, nil
 }

--- a/pkg/kbld/image/tagged.go
+++ b/pkg/kbld/image/tagged.go
@@ -46,7 +46,7 @@ func (i TaggedImage) URL() (string, []ctlconf.Meta, error) {
 			}
 		}
 
-		metas = append(metas, ctlconf.TaggedImageMeta{Type: ctlconf.TaggedMeta, Tags: i.imgDst.Tags})
+		metas = append(metas, ctlconf.NewTaggedImageMeta(i.imgDst.Tags))
 	}
 
 	return url, metas, err

--- a/pkg/kbld/image/tagged.go
+++ b/pkg/kbld/image/tagged.go
@@ -46,7 +46,7 @@ func (i TaggedImage) URL() (string, []ctlconf.Meta, error) {
 			}
 		}
 
-		metas = append(metas, ctlconf.NewTaggedImageMeta(i.imgDst.Tags))
+		metas = append(metas, ctlconf.Meta{Tagged: &ctlconf.MetaTagged{Tags: i.imgDst.Tags}})
 	}
 
 	return url, metas, err

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -17,16 +17,16 @@ images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
     kbld.carvel.dev/metas: |
-      - Tag: 1.14.2
-        Type: resolved
-        URL: nginx:1.14.2
+      - tag: 1.14.2
+        type: resolved
+        url: nginx:1.14.2
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
     kbld.carvel.dev/metas: |
-      - Tag: 1.15.1
-        Type: resolved
-        URL: nginx:1.15.1
+      - tag: 1.15.1
+        type: resolved
+        url: nginx:1.15.1
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `
@@ -36,22 +36,22 @@ images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
     kbld.carvel.dev/metas: |
-      - Path: path/to/source
-        Type: local
-      - Dirty: true
-        RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
-        SHA: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
-        Type: git
+      - path: path/to/source
+        type: local
+      - dirty: true
+        remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
+        sha: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
+        type: git
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
     kbld.carvel.dev/metas: |
-      - Path: path/to/source
-        Type: local
-      - Dirty: true
-        RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
-        SHA: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
-        Type: git
+      - path: path/to/source
+        type: local
+      - dirty: true
+        remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
+        sha: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
+        type: git
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `
@@ -61,26 +61,26 @@ images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
     kbld.carvel.dev/metas: |
-      - Path: path/to/source
-        Type: local
-      - Dirty: true
-        RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
-        SHA: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
-        Type: git
-      - Type: preresolved
-        URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+      - path: path/to/source
+        type: local
+      - dirty: true
+        remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
+        sha: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
+        type: git
+      - type: preresolved
+        url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
     kbld.carvel.dev/metas: |
-      - Path: path/to/source
-        Type: local
-      - Dirty: true
-        RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
-        SHA: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
-        Type: git
-      - Type: preresolved
-        URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+      - path: path/to/source
+        type: local
+      - dirty: true
+        remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
+        sha: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
+        type: git
+      - type: preresolved
+        url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `
@@ -279,20 +279,20 @@ images:
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - Metas:
-        - Tag: 1.15.1
-          Type: resolved
-          URL: nginx:1.15.1
-        - Type: preresolved
-          URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
-        URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
-      - Metas:
-        - Tag: 1.14.2
-          Type: resolved
-          URL: nginx:1.14.2
-        - Type: preresolved
-          URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
-        URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+      - metas:
+        - tag: 1.15.1
+          type: resolved
+          url: nginx:1.15.1
+        - type: preresolved
+          url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+        url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+      - metas:
+        - tag: 1.14.2
+          type: resolved
+          url: nginx:1.14.2
+        - type: preresolved
+          url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+        url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 `
 	if out != expectedOut {
 		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", out, expectedOut)
@@ -323,26 +323,26 @@ images:
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - Metas:
-        - Path: path/to/source
-          Type: local
-        - Dirty: true
-          RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
-          SHA: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
-          Type: git
-        - Type: preresolved
-          URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
-        URL: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
-      - Metas:
-        - Path: path/to/source
-          Type: local
-        - Dirty: true
-          RemoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
-          SHA: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
-          Type: git
-        - Type: preresolved
-          URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
-        URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+      - metas:
+        - path: path/to/source
+          type: local
+        - dirty: true
+          remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
+          sha: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
+          type: git
+        - type: preresolved
+          url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+        url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+      - metas:
+        - path: path/to/source
+          type: local
+        - dirty: true
+          remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
+          sha: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
+          type: git
+        - type: preresolved
+          url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+        url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 `
 	if out != expectedOut {
 		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", out, expectedOut)

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -17,16 +17,16 @@ images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
     kbld.carvel.dev/metas: |
-      - tag: 1.14.2
-        type: resolved
-        url: nginx:1.14.2
+      - resolved:
+          tag: 1.14.2
+          url: nginx:1.14.2
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
     kbld.carvel.dev/metas: |
-      - tag: 1.15.1
-        type: resolved
-        url: nginx:1.15.1
+      - resolved:
+          tag: 1.15.1
+          url: nginx:1.15.1
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `
@@ -36,22 +36,22 @@ images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
     kbld.carvel.dev/metas: |
-      - path: path/to/source
-        type: local
-      - dirty: true
-        remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
-        sha: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
-        type: git
+      - local:
+          path: path/to/source
+      - git:
+          dirty: true
+          remoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+          sha: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
     kbld.carvel.dev/metas: |
-      - path: path/to/source
-        type: local
-      - dirty: true
-        remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
-        sha: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
-        type: git
+      - local:
+          path: path/to/source
+      - git:
+          dirty: true
+          remoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+          sha: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `
@@ -61,26 +61,26 @@ images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
     kbld.carvel.dev/metas: |
-      - path: path/to/source
-        type: local
-      - dirty: true
-        remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
-        sha: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
-        type: git
-      - type: preresolved
-        url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+      - local:
+          path: path/to/source
+      - git:
+          dirty: true
+          remoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+          sha: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
+      - preresolved:
+          url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
     kbld.carvel.dev/metas: |
-      - path: path/to/source
-        type: local
-      - dirty: true
-        remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
-        sha: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
-        type: git
-      - type: preresolved
-        url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+      - local:
+          path: path/to/source
+      - git:
+          dirty: true
+          remoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+          sha: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
+      - preresolved:
+          url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `
@@ -280,18 +280,18 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - metas:
-        - tag: 1.15.1
-          type: resolved
-          url: nginx:1.15.1
-        - type: preresolved
-          url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+        - resolved:
+            tag: 1.15.1
+            url: nginx:1.15.1
+        - preresolved:
+            url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
         url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
       - metas:
-        - tag: 1.14.2
-          type: resolved
-          url: nginx:1.14.2
-        - type: preresolved
-          url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+        - resolved:
+            tag: 1.14.2
+            url: nginx:1.14.2
+        - preresolved:
+            url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
         url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 `
 	if out != expectedOut {
@@ -324,24 +324,24 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - metas:
-        - path: path/to/source
-          type: local
-        - dirty: true
-          remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
-          sha: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
-          type: git
-        - type: preresolved
-          url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
+        - local:
+            path: path/to/source
+        - git:
+            dirty: true
+            remoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+            sha: 4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1
+        - preresolved:
+            url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
         url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
       - metas:
-        - path: path/to/source
-          type: local
-        - dirty: true
-          remoteUrl: git@github.com:vmware-tanzu/carvel-kbld.git
-          sha: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
-          type: git
-        - type: preresolved
-          url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+        - local:
+            path: path/to/source
+        - git:
+            dirty: true
+            remoteURL: git@github.com:vmware-tanzu/carvel-kbld.git
+            sha: f7988fb6c02e0ce69257d9bd9cf37ae20a60f1d
+        - preresolved:
+            url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
         url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 `
 	if out != expectedOut {

--- a/test/e2e/resolve_test.go
+++ b/test/e2e/resolve_test.go
@@ -69,16 +69,16 @@ kind: Object
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - Metas:
-        - Tag: 1.14.2
-          Type: resolved
-          URL: nginx:1.14.2
-        URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
-      - Metas:
-        - Tag: 1.14.2
-          Type: resolved
-          URL: library/nginx:1.14.2
-        URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+      - metas:
+        - tag: 1.14.2
+          type: resolved
+          url: nginx:1.14.2
+        url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+      - metas:
+        - tag: 1.14.2
+          type: resolved
+          url: library/nginx:1.14.2
+        url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 spec:
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
@@ -125,18 +125,18 @@ kind: Object
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - Metas:
-        - Type: preresolved
-          URL: aaa
-        URL: aaa
-      - Metas:
-        - Type: preresolved
-          URL: bbb
-        URL: bbb
-      - Metas:
-        - Type: preresolved
-          URL: ccc
-        URL: ccc
+      - metas:
+        - type: preresolved
+          url: aaa
+        url: aaa
+      - metas:
+        - type: preresolved
+          url: bbb
+        url: bbb
+      - metas:
+        - type: preresolved
+          url: ccc
+        url: ccc
 spec:
 - image: bbb
 - image: aaa
@@ -491,16 +491,16 @@ kind: Object
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - Metas:
-        - Tag: 1.14.1
-          Type: resolved
-          URL: index.docker.io/library/nginx:1.14.1
-        URL: index.docker.io/library/nginx@sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228
-      - Metas:
-        - Tag: 1.14.2
-          Type: resolved
-          URL: index.docker.io/library/nginx:1.14.2
-        URL: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+      - metas:
+        - tag: 1.14.1
+          type: resolved
+          url: index.docker.io/library/nginx:1.14.1
+        url: index.docker.io/library/nginx@sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228
+      - metas:
+        - tag: 1.14.2
+          type: resolved
+          url: index.docker.io/library/nginx:1.14.2
+        url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 spec:
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - image: index.docker.io/library/nginx@sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228

--- a/test/e2e/resolve_test.go
+++ b/test/e2e/resolve_test.go
@@ -70,14 +70,14 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - metas:
-        - tag: 1.14.2
-          type: resolved
-          url: nginx:1.14.2
+        - resolved:
+            tag: 1.14.2
+            url: nginx:1.14.2
         url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
       - metas:
-        - tag: 1.14.2
-          type: resolved
-          url: library/nginx:1.14.2
+        - resolved:
+            tag: 1.14.2
+            url: library/nginx:1.14.2
         url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 spec:
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
@@ -126,16 +126,16 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - metas:
-        - type: preresolved
-          url: aaa
+        - preresolved:
+            url: aaa
         url: aaa
       - metas:
-        - type: preresolved
-          url: bbb
+        - preresolved:
+            url: bbb
         url: bbb
       - metas:
-        - type: preresolved
-          url: ccc
+        - preresolved:
+            url: ccc
         url: ccc
 spec:
 - image: bbb
@@ -492,14 +492,14 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - metas:
-        - tag: 1.14.1
-          type: resolved
-          url: index.docker.io/library/nginx:1.14.1
+        - resolved:
+            tag: 1.14.1
+            url: index.docker.io/library/nginx:1.14.1
         url: index.docker.io/library/nginx@sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228
       - metas:
-        - tag: 1.14.2
-          type: resolved
-          url: index.docker.io/library/nginx:1.14.2
+        - resolved:
+            tag: 1.14.2
+            url: index.docker.io/library/nginx:1.14.2
         url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 spec:
 - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d


### PR DESCRIPTION
- remove "yaml:" struct field tags; our YAML is being processed through
  sigs.k8s.io/yaml (which performs (un)marshaling through the JSON
  parser, not directly through go-yaml/yaml.
- lowercase all field names (consistent with YAML around it, making it easier to read)
- promote "Type" fields as top-level keys for each type of meta.