### PR TITLE
Rename "meta" to "origin"

### DIFF
--- a/pkg/kbld/cmd/image.go
+++ b/pkg/kbld/cmd/image.go
@@ -14,9 +14,9 @@ import (
 type Images []Image
 
 type Image struct {
-	URL      string
-	Metas    []ctlconf.Meta // empty when deserialized
-	metasRaw []interface{}  // populated when deserialized
+	URL        string
+	Origins    []ctlconf.Origin // empty when deserialized
+	originsRaw []interface{}    // populated when deserialized
 }
 
 func (imgs Images) ForImage(url string) (Image, bool) {
@@ -30,7 +30,7 @@ func (imgs Images) ForImage(url string) (Image, bool) {
 
 // TODO only works after deserialization
 func (i Image) Description() string {
-	yamlBytes, err := yaml.Marshal(i.metasRaw)
+	yamlBytes, err := yaml.Marshal(i.originsRaw)
 	if err != nil {
 		return "[]" // TODO deal better?
 	}
@@ -39,12 +39,12 @@ func (i Image) Description() string {
 }
 
 type imageStruct struct {
-	URL   string        `json:"url"`
-	Metas []interface{} `json:"metas,omitempty"`
+	URL     string        `json:"url"`
+	Origins []interface{} `json:"origins,omitempty"`
 }
 
 func (st imageStruct) equal(other imageStruct) bool {
-	return st.URL == other.URL && reflect.DeepEqual(st.Metas, other.Metas)
+	return st.URL == other.URL && reflect.DeepEqual(st.Origins, other.Origins)
 }
 
 func contains(structs []imageStruct, st imageStruct) bool {
@@ -60,9 +60,9 @@ func newImageStructs(images []Image) []imageStruct {
 	var result []imageStruct
 	for _, img := range images {
 		st := newImageStruct(img)
-		// if Metas is empty then the image was already in digest form and we didn't need to resolve
+		// if Origins is empty then the image was already in digest form and we didn't need to resolve
 		// it, so the annotation isn't very useful
-		if len(st.Metas) > 0 {
+		if len(st.Origins) > 0 {
 			// also check for duplicates before adding
 			if !contains(result, st) {
 				result = append(result, st)
@@ -74,8 +74,8 @@ func newImageStructs(images []Image) []imageStruct {
 
 func newImageStruct(image Image) imageStruct {
 	result := imageStruct{URL: image.URL}
-	for _, meta := range image.Metas {
-		result.Metas = append(result.Metas, meta)
+	for _, origin := range image.Origins {
+		result.Origins = append(result.Origins, origin)
 	}
 	return result
 }
@@ -83,7 +83,7 @@ func newImageStruct(image Image) imageStruct {
 func newImages(structs []imageStruct) []Image {
 	var result []Image
 	for _, st := range structs {
-		result = append(result, Image{URL: st.URL, metasRaw: st.Metas})
+		result = append(result, Image{URL: st.URL, originsRaw: st.Origins})
 	}
 	return result
 }

--- a/pkg/kbld/cmd/image_queue.go
+++ b/pkg/kbld/cmd/image_queue.go
@@ -55,7 +55,7 @@ func (b *ImageQueue) worker(workWg *sync.WaitGroup, queueCh <-chan UnprocessedIm
 func (b *ImageQueue) work(workWg *sync.WaitGroup, unprocessedImageURL UnprocessedImageURL) {
 	defer workWg.Done()
 
-	imgURL, metas, err := b.imgFactory.New(unprocessedImageURL.URL).URL()
+	imgURL, origins, err := b.imgFactory.New(unprocessedImageURL.URL).URL()
 	if err != nil {
 		b.outputErrsLock.Lock()
 		b.outputErrs = append(b.outputErrs, fmt.Errorf("Resolving image '%s': %s", unprocessedImageURL.URL, err))
@@ -64,6 +64,6 @@ func (b *ImageQueue) work(workWg *sync.WaitGroup, unprocessedImageURL Unprocesse
 	}
 
 	b.outputImagesLock.Lock()
-	b.outputImages.Add(unprocessedImageURL, Image{URL: imgURL, Metas: metas})
+	b.outputImages.Add(unprocessedImageURL, Image{URL: imgURL, Origins: origins})
 	b.outputImagesLock.Unlock()
 }

--- a/pkg/kbld/cmd/inspect.go
+++ b/pkg/kbld/cmd/inspect.go
@@ -67,14 +67,14 @@ func (o *InspectOptions) Run() error {
 	}
 
 	for _, resWithImg := range foundImages {
-		metasDesc, err := resWithImg.MetasDescription()
+		originsDesc, err := resWithImg.OriginsDescription()
 		if err != nil {
 			return err
 		}
 
 		table.Rows = append(table.Rows, []uitable.Value{
 			uitable.NewValueString(resWithImg.URL),
-			uitable.NewValueString(metasDesc),
+			uitable.NewValueString(originsDesc),
 			uitable.NewValueString(resWithImg.Resource.Description()),
 		})
 	}
@@ -106,7 +106,7 @@ type foundResourceWithImage struct {
 	Resource ctlres.Resource
 }
 
-func (s foundResourceWithImage) MetasDescription() (string, error) {
+func (s foundResourceWithImage) OriginsDescription() (string, error) {
 	images, err := NewResourceWithImages(s.Resource.DeepCopyRaw(), nil).Images()
 	if err != nil {
 		return "", err

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -259,12 +259,12 @@ func (o *ResolveOptions) imgpkgLockAnnotations(i ProcessedImageItem) map[string]
 	anns := map[string]string{
 		ctlconf.ImagesLockKbldID: i.UnprocessedImageURL.URL,
 	}
-	if len(i.Metas) > 0 {
-		bs, err := yaml.Marshal(i.Metas)
+	if len(i.Origins) > 0 {
+		bs, err := yaml.Marshal(i.Origins)
 		if err != nil {
 			return anns
 		}
-		anns[ctlconf.ImagesLockKbldMetas] = string(bs)
+		anns[ctlconf.ImagesLockKbldOrigins] = string(bs)
 	}
 
 	return anns

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -68,7 +68,7 @@ type ImageOverride struct {
 	NewImage     string                     `json:"newImage"`
 	Preresolved  bool                       `json:"preresolved,omitempty"`
 	TagSelection *versions.VersionSelection `json:"tagSelection,omitempty"`
-	ImageMetas   []Meta                     `json:"metas,omitempty"`
+	ImageOrigins []Origin                   `json:"origins,omitempty"`
 }
 
 type ImageDestination struct {
@@ -169,17 +169,17 @@ func NewConfigFromImagesLock(res ctlres.Resource) (Config, error) {
 	overridesConfig := NewConfig()
 
 	for _, image := range imagesLock.Images {
-		imgMeta, err := NewMetasFromString(image.Annotations[ImagesLockKbldMetas])
+		imgOrigins, err := NewOriginsFromString(image.Annotations[ImagesLockKbldOrigins])
 		if err != nil {
-			return Config{}, fmt.Errorf("Unmarshaling %s as %s annotation:  %s", res.Description(), ImagesLockKbldMetas, err)
+			return Config{}, fmt.Errorf("Unmarshaling %s as %s annotation:  %s", res.Description(), ImagesLockKbldOrigins, err)
 		}
 		iOverride := ImageOverride{
 			ImageRef: ImageRef{
 				Image: image.Annotations[ImagesLockKbldID],
 			},
-			NewImage:    image.Image,
-			Preresolved: true,
-			ImageMetas:  imgMeta,
+			NewImage:     image.Image,
+			Preresolved:  true,
+			ImageOrigins: imgOrigins,
 		}
 		overridesConfig.Overrides = append(overridesConfig.Overrides, iOverride)
 	}

--- a/pkg/kbld/config/images_lock.go
+++ b/pkg/kbld/config/images_lock.go
@@ -4,6 +4,6 @@
 package config
 
 const (
-	ImagesLockKbldID    = "kbld.carvel.dev/id"
-	ImagesLockKbldMetas = "kbld.carvel.dev/metas"
+	ImagesLockKbldID      = "kbld.carvel.dev/id"
+	ImagesLockKbldOrigins = "kbld.carvel.dev/origins"
 )

--- a/pkg/kbld/image/built.go
+++ b/pkg/kbld/image/built.go
@@ -32,8 +32,8 @@ func NewBuiltImage(url string, buildSource ctlconf.Source, imgDst *ctlconf.Image
 	return BuiltImage{url, buildSource, imgDst, docker, pack, kubectlBuildkit, ko, bazel}
 }
 
-func (i BuiltImage) URL() (string, []ctlconf.Meta, error) {
-	metas, err := i.sources()
+func (i BuiltImage) URL() (string, []ctlconf.Origin, error) {
+	origins, err := i.sources()
 	if err != nil {
 		return "", nil, err
 	}
@@ -54,12 +54,12 @@ func (i BuiltImage) URL() (string, []ctlconf.Meta, error) {
 			return "", nil, err
 		}
 
-		return i.optionalPushWithDocker(dockerTmpRef, metas)
+		return i.optionalPushWithDocker(dockerTmpRef, origins)
 
 	case i.buildSource.KubectlBuildkit != nil:
 		url, err := i.kubectlBuildkit.BuildAndPush(
 			urlRepo, i.buildSource.Path, i.imgDst, *i.buildSource.KubectlBuildkit)
-		return url, metas, err
+		return url, origins, err
 
 	case i.buildSource.Ko != nil:
 		dockerTmpRef, err := i.ko.Build(urlRepo, i.buildSource.Path, i.buildSource.Ko.Build)
@@ -67,7 +67,7 @@ func (i BuiltImage) URL() (string, []ctlconf.Meta, error) {
 			return "", nil, err
 		}
 
-		return i.optionalPushWithDocker(dockerTmpRef, metas)
+		return i.optionalPushWithDocker(dockerTmpRef, origins)
 
 	case i.buildSource.Bazel != nil:
 		dockerTmpRef, err := i.bazel.Run(urlRepo, i.buildSource.Path, i.buildSource.Bazel.Run)
@@ -75,7 +75,7 @@ func (i BuiltImage) URL() (string, []ctlconf.Meta, error) {
 			return "", nil, err
 		}
 
-		return i.optionalPushWithDocker(dockerTmpRef, metas)
+		return i.optionalPushWithDocker(dockerTmpRef, origins)
 
 	default:
 		if i.buildSource.Docker == nil {
@@ -96,30 +96,30 @@ func (i BuiltImage) URL() (string, []ctlconf.Meta, error) {
 			return "", nil, err
 		}
 
-		return i.optionalPushWithDocker(dockerTmpRef, metas)
+		return i.optionalPushWithDocker(dockerTmpRef, origins)
 	}
 }
 
-func (i BuiltImage) optionalPushWithDocker(dockerTmpRef ctlbdk.DockerTmpRef, metas []ctlconf.Meta) (string, []ctlconf.Meta, error) {
+func (i BuiltImage) optionalPushWithDocker(dockerTmpRef ctlbdk.DockerTmpRef, origins []ctlconf.Origin) (string, []ctlconf.Origin, error) {
 	if i.imgDst != nil {
 		digest, err := i.docker.Push(dockerTmpRef, i.imgDst.NewImage)
 		if err != nil {
 			return "", nil, err
 		}
 
-		url, metas2, err := NewDigestedImageFromParts(i.imgDst.NewImage, digest.AsString()).URL()
+		url, moreOrigins, err := NewDigestedImageFromParts(i.imgDst.NewImage, digest.AsString()).URL()
 		if err != nil {
 			return "", nil, err
 		}
 
-		return url, append(metas, metas2...), nil
+		return url, append(origins, moreOrigins...), nil
 	}
 
-	return dockerTmpRef.AsString(), metas, nil
+	return dockerTmpRef.AsString(), origins, nil
 }
 
-func (i BuiltImage) sources() ([]ctlconf.Meta, error) {
-	var sources []ctlconf.Meta
+func (i BuiltImage) sources() ([]ctlconf.Origin, error) {
+	var sources []ctlconf.Origin
 
 	absPath, err := filepath.Abs(i.buildSource.Path)
 	if err != nil {

--- a/pkg/kbld/image/digested.go
+++ b/pkg/kbld/image/digested.go
@@ -41,7 +41,7 @@ func NewDigestedImageFromParts(url, digest string) DigestedImage {
 	return DigestedImage{nameWithDigest, nil}
 }
 
-func (i DigestedImage) URL() (string, []ctlconf.Meta, error) {
+func (i DigestedImage) URL() (string, []ctlconf.Origin, error) {
 	if i.parseErr != nil {
 		return "", nil, i.parseErr
 	}

--- a/pkg/kbld/image/factory.go
+++ b/pkg/kbld/image/factory.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Image interface {
-	URL() (string, []ctlconf.Meta, error)
+	URL() (string, []ctlconf.Origin, error)
 }
 
 type Factory struct {
@@ -32,7 +32,7 @@ func (f Factory) New(url string) Image {
 	if overrideConf, found := f.shouldOverride(url); found {
 		url = overrideConf.NewImage
 		if overrideConf.Preresolved {
-			return NewPreresolvedImage(url, overrideConf.ImageMetas)
+			return NewPreresolvedImage(url, overrideConf.ImageOrigins)
 		} else if overrideConf.TagSelection != nil {
 			return NewTagSelectedImage(url, overrideConf.TagSelection, f.registry)
 		}

--- a/pkg/kbld/image/preresolved.go
+++ b/pkg/kbld/image/preresolved.go
@@ -8,21 +8,21 @@ import (
 )
 
 type PreresolvedImage struct {
-	url   string
-	metas []ctlconf.Meta
+	url     string
+	origins []ctlconf.Origin
 }
 
-func NewPreresolvedImage(url string, metas []ctlconf.Meta) PreresolvedImage {
-	return PreresolvedImage{url, copyAndAppendMeta(metas)}
+func NewPreresolvedImage(url string, origins []ctlconf.Origin) PreresolvedImage {
+	return PreresolvedImage{url, copyAndAppendOrigins(origins)}
 }
 
-func (i PreresolvedImage) URL() (string, []ctlconf.Meta, error) {
-	imageMetas := copyAndAppendMeta(i.metas, ctlconf.NewPreresolvedImageSourceURL(i.url))
+func (i PreresolvedImage) URL() (string, []ctlconf.Origin, error) {
+	imageMetas := copyAndAppendOrigins(i.origins, ctlconf.NewPreresolvedImageSourceURL(i.url))
 	return i.url, imageMetas, nil
 }
 
-func copyAndAppendMeta(existing []ctlconf.Meta, new ...ctlconf.Meta) []ctlconf.Meta {
-	all := make([]ctlconf.Meta, len(existing), len(existing)+len(new))
+func copyAndAppendOrigins(existing []ctlconf.Origin, new ...ctlconf.Origin) []ctlconf.Origin {
+	all := make([]ctlconf.Origin, len(existing), len(existing)+len(new))
 	copy(all, existing)
 	return append(all, new...)
 }

--- a/pkg/kbld/image/resolved.go
+++ b/pkg/kbld/image/resolved.go
@@ -21,7 +21,7 @@ func NewResolvedImage(url string, registry ctlreg.Registry) ResolvedImage {
 	return ResolvedImage{url, registry}
 }
 
-func (i ResolvedImage) URL() (string, []ctlconf.Meta, error) {
+func (i ResolvedImage) URL() (string, []ctlconf.Origin, error) {
 	tag, err := regname.NewTag(i.url, regname.WeakValidation)
 	if err != nil {
 		return "", nil, err
@@ -44,14 +44,14 @@ func (i ResolvedImage) URL() (string, []ctlconf.Meta, error) {
 		return "", nil, fmt.Errorf("Expected digest resolution to be consistent over two separate requests")
 	}
 
-	url, metas, err := NewDigestedImageFromParts(tag.Repository.String(), imgDescriptor.Digest.String()).URL()
+	url, origins, err := NewDigestedImageFromParts(tag.Repository.String(), imgDescriptor.Digest.String()).URL()
 	if err != nil {
 		return "", nil, err
 	}
 
 	resolvedSource := ctlconf.NewResolvedImageSourceURL(i.url)
 	resolvedSource.Details.Tag = tag.TagStr()
-	metas = append(metas, resolvedSource)
+	origins = append(origins, resolvedSource)
 
-	return url, metas, nil
+	return url, origins, nil
 }

--- a/pkg/kbld/image/tag_selected.go
+++ b/pkg/kbld/image/tag_selected.go
@@ -25,7 +25,7 @@ func NewTagSelectedImage(url string, selection *versions.VersionSelection,
 	return TagSelectedImage{url, selection, registry}
 }
 
-func (i TagSelectedImage) URL() (string, []ctlconf.Meta, error) {
+func (i TagSelectedImage) URL() (string, []ctlconf.Origin, error) {
 	repo, err := regname.NewRepository(i.url, regname.WeakValidation)
 	if err != nil {
 		return "", nil, err

--- a/pkg/kbld/image/tagged.go
+++ b/pkg/kbld/image/tagged.go
@@ -20,8 +20,8 @@ func NewTaggedImage(image Image, imgDst ctlconf.ImageDestination, registry ctlre
 	return TaggedImage{image, imgDst, registry}
 }
 
-func (i TaggedImage) URL() (string, []ctlconf.Meta, error) {
-	url, metas, err := i.image.URL()
+func (i TaggedImage) URL() (string, []ctlconf.Origin, error) {
+	url, origins, err := i.image.URL()
 	if err != nil {
 		return "", nil, err
 	}
@@ -46,8 +46,8 @@ func (i TaggedImage) URL() (string, []ctlconf.Meta, error) {
 			}
 		}
 
-		metas = append(metas, ctlconf.NewTaggedImageMeta(i.imgDst.Tags))
+		origins = append(origins, ctlconf.NewTaggedImageOrigin(i.imgDst.Tags))
 	}
 
-	return url, metas, err
+	return url, origins, err
 }

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -11,31 +11,31 @@ import (
 )
 
 var (
-	imgLockWithResolvedMetas = `---
+	imgLockWithResolvedOrigins = `---
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
-    kbld.carvel.dev/metas: |
+    kbld.carvel.dev/origins: |
       - resolved:
           tag: 1.14.2
           url: nginx:1.14.2
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
-    kbld.carvel.dev/metas: |
+    kbld.carvel.dev/origins: |
       - resolved:
           tag: 1.15.1
           url: nginx:1.15.1
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `
-	imgLockWithBuiltMetas = `---
+	imgLockWithBuiltOrigins = `---
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
-    kbld.carvel.dev/metas: |
+    kbld.carvel.dev/origins: |
       - local:
           path: path/to/source
       - git:
@@ -45,7 +45,7 @@ images:
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
-    kbld.carvel.dev/metas: |
+    kbld.carvel.dev/origins: |
       - local:
           path: path/to/source
       - git:
@@ -55,12 +55,12 @@ images:
   image: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
 kind: ImagesLock
 `
-	imgLockWithBuiltAndPreresolvedMetas = `---
+	imgLockWithBuiltAndPreresolvedOrigins = `---
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: nginx:1.14.2
-    kbld.carvel.dev/metas: |
+    kbld.carvel.dev/origins: |
       - local:
           path: path/to/source
       - git:
@@ -72,7 +72,7 @@ images:
   image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
 - annotations:
     kbld.carvel.dev/id: sample-app
-    kbld.carvel.dev/metas: |
+    kbld.carvel.dev/origins: |
       - local:
           path: path/to/source
       - git:
@@ -237,8 +237,8 @@ images:
 		t.Fatalf("Failed while reading " + path)
 	}
 
-	if string(bs) != imgLockWithResolvedMetas {
-		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLockWithResolvedMetas)
+	if string(bs) != imgLockWithResolvedOrigins {
+		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLockWithResolvedOrigins)
 	}
 }
 
@@ -266,7 +266,7 @@ images:
 - image: nginx:1.14.2
 - image: sample-app
 ---
-` + imgLockWithResolvedMetas
+` + imgLockWithResolvedOrigins
 
 	out, _ := kbld.RunWithOpts([]string{"-f", "-"}, RunOpts{
 		StdinReader: strings.NewReader(input),
@@ -279,14 +279,14 @@ images:
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - metas:
+      - origins:
         - resolved:
             tag: 1.15.1
             url: nginx:1.15.1
         - preresolved:
             url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
         url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
-      - metas:
+      - origins:
         - resolved:
             tag: 1.14.2
             url: nginx:1.14.2
@@ -299,7 +299,7 @@ metadata:
 	}
 }
 
-func TestImgpkgLockFileMetasSuccessful(t *testing.T) {
+func TestImgpkgLockFileOriginsSuccessful(t *testing.T) {
 	env := BuildEnv(t)
 	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
 
@@ -308,9 +308,9 @@ images:
 - image: nginx:1.14.2
 - image: sample-app
 ---
-` + imgLockWithBuiltMetas
+` + imgLockWithBuiltOrigins
 
-	path := "/tmp/kbld-test-lock-metas"
+	path := "/tmp/kbld-test-lock-origins"
 	defer os.RemoveAll(path)
 	out, _ := kbld.RunWithOpts([]string{"-f", "-", "--imgpkg-lock-output=" + path}, RunOpts{
 		StdinReader: strings.NewReader(input),
@@ -323,7 +323,7 @@ images:
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - metas:
+      - origins:
         - local:
             path: path/to/source
         - git:
@@ -333,7 +333,7 @@ metadata:
         - preresolved:
             url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
         url: index.docker.io/library/nginx@sha256:4a5573037f358b6cdfa2f3e8a9c33a5cf11bcd1675ca72ca76fbe5bd77d0d682
-      - metas:
+      - origins:
         - local:
             path: path/to/source
         - git:
@@ -353,12 +353,12 @@ metadata:
 		t.Fatalf("Failed while reading " + path)
 	}
 
-	if string(bs) != imgLockWithBuiltAndPreresolvedMetas {
-		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLockWithBuiltAndPreresolvedMetas)
+	if string(bs) != imgLockWithBuiltAndPreresolvedOrigins {
+		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLockWithBuiltAndPreresolvedOrigins)
 	}
 }
 
-func TestImgpkgLockOutputSuccessfulDigestedImageHasNoMetas(t *testing.T) {
+func TestImgpkgLockOutputSuccessfulDigestedImageHasNoOrigins(t *testing.T) {
 	env := BuildEnv(t)
 	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
 
@@ -389,7 +389,7 @@ images:
 		t.Fatalf("Failed while reading " + path)
 	}
 
-	// For Digest references, Image Lock should not have metas since there is no image metadata
+	// For Digest references, Image Lock should not have origins since there is no image metadata
 	if string(bs) != imgLock {
 		t.Fatalf("Expected >>>%s<<< to match >>>%s<<<", bs, imgLock)
 	}

--- a/test/e2e/resolve_test.go
+++ b/test/e2e/resolve_test.go
@@ -49,7 +49,7 @@ func TestResolveSuccessfulWithAnnotations(t *testing.T) {
 
 	// The repetition in this input is so it can test for:
 	// 1) resolving
-	// 2) filtering annotations with null metas (which happens with digests, which don't get resolved)
+	// 2) filtering annotations with null origins (which happens with digests, which don't get resolved)
 	// 3) de-duplicating annotations
 	input := `
 kind: Object
@@ -69,12 +69,12 @@ kind: Object
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - metas:
+      - origins:
         - resolved:
             tag: 1.14.2
             url: nginx:1.14.2
         url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
-      - metas:
+      - origins:
         - resolved:
             tag: 1.14.2
             url: library/nginx:1.14.2
@@ -125,15 +125,15 @@ kind: Object
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - metas:
+      - origins:
         - preresolved:
             url: aaa
         url: aaa
-      - metas:
+      - origins:
         - preresolved:
             url: bbb
         url: bbb
-      - metas:
+      - origins:
         - preresolved:
             url: ccc
         url: ccc
@@ -491,12 +491,12 @@ kind: Object
 metadata:
   annotations:
     kbld.k14s.io/images: |
-      - metas:
+      - origins:
         - resolved:
             tag: 1.14.1
             url: index.docker.io/library/nginx:1.14.1
         url: index.docker.io/library/nginx@sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228
-      - metas:
+      - origins:
         - resolved:
             tag: 1.14.2
             url: index.docker.io/library/nginx:1.14.2


### PR DESCRIPTION
All of the information being stored in the "metas" section are
information about the sourcing of each image. The term "source" however,
is already used in this domain to mean a configuration from which an
image is produced from sources.

Origin is a softer claim than provenance; the latter of which is
generally taken to mean provable.