### PR TITLE
Fix Meta being undefined

### DIFF
--- a/pkg/kbld/image/err.go
+++ b/pkg/kbld/image/err.go
@@ -3,6 +3,8 @@
 
 package image
 
+import ctlconf "github.com/k14s/kbld/pkg/kbld/config"
+
 type ErrImage struct {
 	err error
 }
@@ -11,4 +13,4 @@ var _ Image = ErrImage{}
 
 func NewErrImage(err error) ErrImage { return ErrImage{err} }
 
-func (i ErrImage) URL() (string, []Meta, error) { return "", nil, i.err }
+func (i ErrImage) URL() (string, []ctlconf.Meta, error) { return "", nil, i.err }


### PR DESCRIPTION
The build is currently not working as shown in logs here: https://github.com/vmware-tanzu/carvel-kbld/runs/3663355548?check_suite_focus=true

The error is `pkg/kbld/image/err.go:14:36: undefined: Meta` which comes from ./hack/build.sh.

This could also be addressed in #167, but regardless that pr should rebase around changes for ErrImage.