### PR TITLE
Add host-only-cidr option when launching minikube for testing

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -49,7 +49,7 @@ jobs:
 
         wget -O- -nv https://github.com/kubernetes/minikube/releases/latest/download/minikube-darwin-amd64 > /tmp/bin/minikube
         chmod +x /tmp/bin/minikube
-        minikube start --driver=virtualbox --insecure-registry=192.168.0.0/16
+        minikube start --driver=virtualbox --insecure-registry=192.168.0.0/16 --host-only-cidr "192.168.59.1/24"
         eval $(minikube docker-env --shell=bash)
 
         # when this workflow runs of a pull request based on a fork, secrets are unavailable

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -18,7 +18,7 @@ Install virtualbox from https://www.virtualbox.org/wiki/Downloads. After install
 ```bash
 # Bootstrap k8s cluster and enable docker registry
 # X.X.X.X must be replaced with your subnetmask of "minikube ip"
-minikube start --driver=virtualbox --insecure-registry=X.X.X.X/16
+minikube start --driver=virtualbox --insecure-registry=X.X.X.X/16 --host-only-cidr "192.168.59.1/24"
 # Build kbld binary for testing
 ./hack/build.sh
 # Make your env aware of the docker registry


### PR DESCRIPTION
Due to a change in VirtualBox change minikube needs to use a different CIDR.
Check https://github.com/kubernetes/minikube/issues/12765#issuecomment-953931265