### PR TITLE
Explicit set Go version for linting in CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,16 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - name: Install Go 1.17
+        uses: actions/setup-go@v3
         with:
-          version: v1.34
+          go-version: "1.17"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.45.2
           args: -v
+


### PR DESCRIPTION
Addresses build break from golangci-lint-action autoinstalling go v1.18: https://kubernetes.slack.com/archives/CH8KCCKA5/p1648847055663899