### PR TITLE
support platform selection flag and configuration

### DIFF
--- a/pkg/kbld/cmd/resolve_test.go
+++ b/pkg/kbld/cmd/resolve_test.go
@@ -1,0 +1,74 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ctlcmd "github.com/vmware-tanzu/carvel-kbld/pkg/kbld/cmd"
+	ctlconf "github.com/vmware-tanzu/carvel-kbld/pkg/kbld/config"
+)
+
+func TestNewPlatformSelection(t *testing.T) {
+	type test struct {
+		Input string
+		Plat  *ctlconf.PlatformSelection
+		Error error
+	}
+
+	exs := []test{
+		{
+			Input: "",
+			Error: fmt.Errorf("Parsing platform '': expected format os/arch[/variant]"),
+		}, {
+			Input: "linux/386",
+			Plat: &ctlconf.PlatformSelection{
+				Architecture: "386",
+				OS:           "linux",
+			},
+		}, {
+			Input: "linux/arm/v7",
+			Plat: &ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "linux",
+				Variant:      "v7",
+			},
+		}, {
+			Input: "linux/arm/v6",
+			Plat: &ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "linux",
+				Variant:      "v6",
+			},
+		}, {
+			Input: "linux/arm:version",
+			Plat: &ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "version",
+			},
+		}, {
+			Input: "linux/arm/v6:version",
+			Plat: &ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "version",
+				Variant:      "v6",
+			},
+		}, {
+			Input: "linux/arm/v6/another",
+			Error: fmt.Errorf("Parsing platform 'linux/arm/v6/another': too many slashes"),
+		},
+	}
+
+	for _, ex := range exs {
+		t.Run(fmt.Sprintf("parsing '%s'", ex.Input), func(t *testing.T) {
+			plat, err := ctlcmd.NewPlatformSelection(ex.Input)
+			assert.Equal(t, err, ex.Error)
+			assert.Equal(t, plat, ex.Plat)
+		})
+	}
+}

--- a/pkg/kbld/config/config.go
+++ b/pkg/kbld/config/config.go
@@ -65,10 +65,22 @@ type Source struct {
 
 type ImageOverride struct {
 	ImageRef
-	NewImage     string                     `json:"newImage"`
-	Preresolved  bool                       `json:"preresolved,omitempty"`
-	TagSelection *versions.VersionSelection `json:"tagSelection,omitempty"`
-	ImageOrigins []Origin                   `json:"origins,omitempty"`
+	NewImage          string                     `json:"newImage"`
+	Preresolved       bool                       `json:"preresolved,omitempty"`
+	TagSelection      *versions.VersionSelection `json:"tagSelection,omitempty"`
+	PlatformSelection *PlatformSelection         `json:"platformSelection,omitempty"`
+	ImageOrigins      []Origin                   `json:"origins,omitempty"`
+}
+
+// PlatformSelection
+// https://github.com/opencontainers/image-spec/blob/main/image-index.md#image-index-property-descriptions
+type PlatformSelection struct {
+	Architecture string   `json:"architecture,omitempty"`
+	OS           string   `json:"os,omitempty"`
+	OSVersion    string   `json:"os.version,omitempty"`  // note dot
+	OSFeatures   []string `json:"os.features,omitempty"` // note dot
+	Variant      string   `json:"variant,omitempty"`
+	Features     []string `json:"features,omitempty"`
 }
 
 type ImageDestination struct {

--- a/pkg/kbld/config/image_origin.go
+++ b/pkg/kbld/config/image_origin.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Origin struct {
-	Git         *OriginGit         `json:"git,omitempty"`
-	Local       *OriginLocal       `json:"local,omitempty"`
-	Resolved    *OriginResolved    `json:"resolved,omitempty"`
-	Tagged      *OriginTagged      `json:"tagged,omitempty"`
-	Preresolved *OriginPreresolved `json:"preresolved,omitempty"`
+	Git              *OriginGit              `json:"git,omitempty"`
+	Local            *OriginLocal            `json:"local,omitempty"`
+	Resolved         *OriginResolved         `json:"resolved,omitempty"`
+	Tagged           *OriginTagged           `json:"tagged,omitempty"`
+	Preresolved      *OriginPreresolved      `json:"preresolved,omitempty"`
+	PlatformSelected *OriginPlatformSelected `json:"platformSelected,omitempty"`
 }
 
 type OriginGit struct {
@@ -37,6 +38,13 @@ type OriginTagged struct {
 
 type OriginPreresolved struct {
 	URL string `json:"url"`
+}
+
+type OriginPlatformSelected struct {
+	Index        string `json:"index,omitempty"`
+	OS           string `json:"os,omitempty"`
+	Architecture string `json:"architecture,omitempty"`
+	Variant      string `json:"variant,omitempty"`
 }
 
 func NewOriginsFromString(str string) ([]Origin, error) {

--- a/pkg/kbld/image/platform_selected.go
+++ b/pkg/kbld/image/platform_selected.go
@@ -1,0 +1,142 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"fmt"
+
+	regname "github.com/google/go-containerregistry/pkg/name"
+	regv1 "github.com/google/go-containerregistry/pkg/v1"
+	regtypes "github.com/google/go-containerregistry/pkg/v1/types"
+	ctlconf "github.com/vmware-tanzu/carvel-kbld/pkg/kbld/config"
+	ctlreg "github.com/vmware-tanzu/carvel-kbld/pkg/kbld/registry"
+)
+
+// PlatformSelectedImage selects specific image matching arch/platform
+type PlatformSelectedImage struct {
+	image     Image
+	selection *ctlconf.PlatformSelection
+	registry  ctlreg.Registry
+}
+
+func NewPlatformSelectedImage(image Image,
+	selection *ctlconf.PlatformSelection, registry ctlreg.Registry) PlatformSelectedImage {
+
+	return PlatformSelectedImage{image, selection, registry}
+}
+
+func (i PlatformSelectedImage) URL() (string, []ctlconf.Origin, error) {
+	url, origins, err := i.image.URL()
+	if err != nil {
+		return url, origins, err
+	}
+
+	// Do nothing if platform selection is not requested
+	if i.selection == nil {
+		return url, origins, err
+	}
+
+	ref, err := regname.ParseReference(url)
+	if err != nil {
+		return "", nil, err
+	}
+
+	desc, err := i.registry.Generic(ref)
+	if err != nil {
+		return "", nil, err
+	}
+
+	switch desc.MediaType {
+	case regtypes.OCIImageIndex, regtypes.DockerManifestList:
+		imgIndex, err := i.registry.Index(ref)
+		if err != nil {
+			return "", nil, err
+		}
+		imgIndexManifest, err := imgIndex.IndexManifest()
+		if err != nil {
+			return "", nil, err
+		}
+
+		var matchedMan *regv1.Descriptor
+
+		for _, man := range imgIndexManifest.Manifests {
+			if man.Platform != nil && MatchesPlatformSelection(*man.Platform, *i.selection) {
+				if matchedMan != nil {
+					return "", nil, fmt.Errorf("Expected to find only one image under index '%s' with matching platform, but found more than one", url)
+				}
+				man := man // copy
+				matchedMan = &man
+			}
+		}
+
+		if matchedMan != nil {
+			newURL, newOrigins, err := NewDigestedImageFromParts(ref.Context().Name(), matchedMan.Digest.String()).URL()
+			if err != nil {
+				return "", nil, err
+			}
+			newOrigins = append(newOrigins, ctlconf.Origin{
+				PlatformSelected: &ctlconf.OriginPlatformSelected{
+					Index:        url,
+					OS:           i.selection.OS,
+					Architecture: i.selection.Architecture,
+					Variant:      i.selection.Variant,
+				},
+			})
+			return newURL, append(origins, newOrigins...), nil
+		}
+
+		return "", nil, fmt.Errorf("Expected to find one image under index '%s' with matching platform, but found none", url)
+
+	// Assume that if it's not an index, then image is all right to use
+	default:
+		return url, origins, nil
+	}
+}
+
+// MatchesPlatformSelection checks if the given platform matches the required platforms.
+// The given platform matches the required platform if
+// - architecture and OS are identical.
+// - OS version and variant are identical if provided.
+// - features and OS features of the required platform are subsets of those of the given platform.
+// Adapted from https://github.com/google/go-containerregistry/blob/570ba6c88a5041afebd4599981d849af96f5dba9/pkg/v1/remote/index.go#L263
+func MatchesPlatformSelection(given regv1.Platform, required ctlconf.PlatformSelection) bool {
+	// Required fields that must be identical.
+	if given.Architecture != required.Architecture || given.OS != required.OS {
+		return false
+	}
+
+	// Optional fields that may be empty, but must be identical if provided.
+	if required.OSVersion != "" && given.OSVersion != required.OSVersion {
+		return false
+	}
+	if required.Variant != "" && given.Variant != required.Variant {
+		return false
+	}
+
+	// Verify required platform's features are a subset of given platform's features.
+	if !isSubset(given.OSFeatures, required.OSFeatures) {
+		return false
+	}
+	if !isSubset(given.Features, required.Features) {
+		return false
+	}
+
+	return true
+}
+
+// isSubset checks if the required array of strings is a subset of the given lst.
+func isSubset(lst, required []string) bool {
+	set := make(map[string]bool)
+	for _, value := range lst {
+		set[value] = true
+	}
+
+	for _, value := range required {
+		if _, ok := set[value]; !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/kbld/image/platform_selected_test.go
+++ b/pkg/kbld/image/platform_selected_test.go
@@ -1,0 +1,267 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package image_test
+
+import (
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	ctlconf "github.com/vmware-tanzu/carvel-kbld/pkg/kbld/config"
+	ctlimg "github.com/vmware-tanzu/carvel-kbld/pkg/kbld/image"
+)
+
+// TestMatchesPlatform runs test cases on the matchesPlatform function which verifies
+// whether the given platform can run on the required platform by checking the
+// compatibility of architecture, OS, OS version, OS features, variant and features.
+// Adapted from https://github.com/google/go-containerregistry/blob/570ba6c88a5041afebd4599981d849af96f5dba9/pkg/v1/remote/index_test.go#L251
+func TestMatchesPlatformSelection(t *testing.T) {
+	tests := []struct {
+		// want is the expected return value from matchesPlatform
+		// when the given platform is 'given' and the required platform is 'required'.
+		given    v1.Platform
+		required ctlconf.PlatformSelection
+		want     bool
+	}{{ // The given & required platforms are identical. matchesPlatform expected to return true.
+		given: v1.Platform{
+			Architecture: "amd64",
+			OS:           "linux",
+			OSVersion:    "10.0.10586",
+			OSFeatures:   []string{"win32k"},
+			Variant:      "armv6l",
+			Features:     []string{"sse4"},
+		},
+		required: ctlconf.PlatformSelection{
+			Architecture: "amd64",
+			OS:           "linux",
+			OSVersion:    "10.0.10586",
+			OSFeatures:   []string{"win32k"},
+			Variant:      "armv6l",
+			Features:     []string{"sse4"},
+		},
+		want: true,
+	},
+		{ // OS and Architecture must exactly match. matchesPlatform expected to return false.
+			given: v1.Platform{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "amd64",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win32k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			want: false,
+		},
+		{ // OS version must exactly match
+			given: v1.Platform{
+				Architecture: "amd64",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "amd64",
+				OS:           "linux",
+				OSVersion:    "10.0.10587",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			want: false,
+		},
+		{ // OS Features must exactly match. matchesPlatform expected to return false.
+			given: v1.Platform{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win32k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			want: false,
+		},
+		{ // Variant must exactly match. matchesPlatform expected to return false.
+			given: v1.Platform{
+				Architecture: "amd64",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "amd64",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "armv7l",
+				Features:     []string{"sse4"},
+			},
+			want: false,
+		},
+		{ // OS must exactly match, and is case sensative. matchesPlatform expected to return false.
+			given: v1.Platform{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "LinuX",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			want: false,
+		},
+		{ // OSVersion and Variant are specified in given but not in required.
+			// matchesPlatform expected to return true.
+			given: v1.Platform{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "",
+				Features:     []string{"sse4"},
+			},
+			want: true,
+		},
+		{ // Ensure the optional field OSVersion & Variant match exactly if specified as required.
+			given: v1.Platform{
+				Architecture: "amd64",
+				OS:           "linux",
+				OSVersion:    "",
+				OSFeatures:   []string{},
+				Variant:      "",
+				Features:     []string{},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "amd64",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win32k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			want: false,
+		},
+		{ // Checking subset validity when required less features than given features.
+			// matchesPlatform expected to return true.
+			given: v1.Platform{
+				Architecture: "",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win32k"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "",
+				OS:           "linux",
+				OSVersion:    "",
+				OSFeatures:   []string{},
+				Variant:      "",
+				Features:     []string{},
+			},
+			want: true,
+		},
+		{ // Checking subset validity when required features are subset of given features.
+			// matchesPlatform expected to return true.
+			given: v1.Platform{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k", "f1", "f2"},
+				Variant:      "",
+				Features:     []string{"sse4", "f1"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "",
+				Features:     []string{"sse4"},
+			},
+			want: true,
+		},
+		{ // Checking subset validity when some required features is not subset of given features.
+			// matchesPlatform expected to return false.
+			given: v1.Platform{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k", "f1", "f2"},
+				Variant:      "",
+				Features:     []string{"sse4", "f1"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k"},
+				Variant:      "",
+				Features:     []string{"sse4", "f2"},
+			},
+			want: false,
+		},
+		{ // Checking subset validity when OS features not required,
+			// and required features is indeed a subset of given features.
+			// matchesPlatform expected to return true.
+			given: v1.Platform{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{"win64k", "f1", "f2"},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			required: ctlconf.PlatformSelection{
+				Architecture: "arm",
+				OS:           "linux",
+				OSVersion:    "10.0.10586",
+				OSFeatures:   []string{},
+				Variant:      "armv6l",
+				Features:     []string{"sse4"},
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		got := ctlimg.MatchesPlatformSelection(test.given, test.required)
+		if got != test.want {
+			t.Errorf("matchesPlatform(%v, %v); got %v, want %v", test.given, test.required, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
allows users to select images (from img indexes) matching only specific platform via global flag or explicit configuration in overrides 