### PR TITLE
Use a build tag for e2e tests

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -26,6 +26,6 @@ go clean -testcache
 
 export KBLD_BINARY_PATH="${KBLD_BINARY_PATH:-$PWD/kbld}"
 
-go test ./test/e2e/ -timeout 60m -test.v $@
+go test -tags=e2e ./test/e2e/ -timeout 60m -test.v $@
 
 echo E2E SUCCESS

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -6,6 +6,6 @@ git --version || (echo "Missing git binary (used by tests)" && exit 1)
 
 go clean -testcache
 
-go test ./pkg/... -test.v $@
+go test ./... -test.v $@
 
 echo UNIT SUCCESS

--- a/test/e2e/build_bazel_test.go
+++ b/test/e2e/build_bazel_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/build_ko_test.go
+++ b/test/e2e/build_ko_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/build_kubectl_buildkit_test.go
+++ b/test/e2e/build_kubectl_buildkit_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/build_pack_test.go
+++ b/test/e2e/build_pack_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/kbld.go
+++ b/test/e2e/kbld.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/packaging_test.go
+++ b/test/e2e/packaging_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/relocate_test.go
+++ b/test/e2e/relocate_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/resolve_test.go
+++ b/test/e2e/resolve_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/tags_test.go
+++ b/test/e2e/tags_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Allows regular `go test ./...` to work