### PR TITLE
Setting buildid is no longer necessary for reproducible builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,6 @@ builds:
       - -trimpath
 
     ldflags:
-      - -buildid=
       - -X github.com/vmware-tanzu/carvel-kbld/pkg/kbld/version.Version={{ .Version }}
 
 archives:

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -14,7 +14,7 @@ go mod tidy
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/vmware-tanzu/carvel-kbld/pkg/kbld/version.Version=$VERSION -buildid="
+LDFLAGS="-X github.com/vmware-tanzu/carvel-kbld/pkg/kbld/version.Version=$VERSION"
 
 GOOS=darwin GOARCH=amd64 go build -ldflags="$LDFLAGS" -trimpath -o kbld-darwin-amd64 ./cmd/kbld/...
 GOOS=darwin GOARCH=arm64 go build -ldflags="$LDFLAGS" -trimpath -o kbld-darwin-arm64 ./cmd/kbld/...

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -7,7 +7,7 @@ VERSION="${1:-$LATEST_GIT_TAG}"
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/vmware-tanzu/carvel-kbld/pkg/kbld/version.Version=$VERSION -buildid="
+LDFLAGS="-X github.com/vmware-tanzu/carvel-kbld/pkg/kbld/version.Version=$VERSION"
 
 go fmt ./cmd/... ./pkg/... ./test/...
 go mod vendor


### PR DESCRIPTION
Fixed in https://github.com/golang/go/commit/aa680c0c49b55722a72ad3772e590cd2f9af541d