### PR TITLE
Fix gofmt ./test/...

### DIFF
--- a/test/e2e/build_bazel_test.go
+++ b/test/e2e/build_bazel_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestBazelBuildAndPushSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 	input := env.WithRegistries(`
 kind: Object
 spec:

--- a/test/e2e/build_ko_test.go
+++ b/test/e2e/build_ko_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestKoBuildAndPushSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := env.WithRegistries(`
 kind: Object

--- a/test/e2e/build_kubectl_buildkit_test.go
+++ b/test/e2e/build_kubectl_buildkit_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestKubectlBuildkitBuildSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 	createBuilder(t)
 
 	input := env.WithRegistries(`
@@ -67,7 +67,7 @@ func TestKubectlBuildkitBuildAndPushSuccessful(t *testing.T) {
 
 	createBuilder(t)
 
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := env.WithRegistries(`
 kind: Object

--- a/test/e2e/build_pack_test.go
+++ b/test/e2e/build_pack_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestPackBuildAndPushSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := env.WithRegistries(`
 kind: Object

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDockerBuildSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := env.WithRegistries(`
 kind: Object
@@ -73,7 +73,7 @@ spec:
 
 func TestDockerBuildAndPushSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := env.WithRegistries(`
 kind: Object
@@ -133,7 +133,7 @@ spec:
 // to avoid having tags that are too long.
 func TestDockerBuildSuccessfulWithImageRepo(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := env.WithRegistries(`
 kind: Object

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,5 +1,3 @@
-//go:build e2e
-
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -1,5 +1,3 @@
-//go:build e2e
-
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Env struct {
-	Namespace            string
 	DockerHubUsername    string
 	DockerHubHostname    string
 	SkipStressTests      bool

--- a/test/e2e/kbld.go
+++ b/test/e2e/kbld.go
@@ -1,5 +1,3 @@
-//go:build e2e
-
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/kbld.go
+++ b/test/e2e/kbld.go
@@ -14,10 +14,9 @@ import (
 )
 
 type Kbld struct {
-	t         *testing.T
-	namespace string
-	kbldPath  string
-	l         Logger
+	t        *testing.T
+	kbldPath string
+	l        Logger
 }
 
 type RunOpts struct {

--- a/test/e2e/lock_output_test.go
+++ b/test/e2e/lock_output_test.go
@@ -101,7 +101,7 @@ kind: ImagesLock
 
 func TestLockOutputSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 images:
@@ -189,7 +189,7 @@ searchRules:
 
 func TestImgpkgLockOutputSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 images:
@@ -246,7 +246,7 @@ images:
 
 func TestImgpkgLockFileNotInOutput(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := imgLock
 	out, _ := kbld.RunWithOpts([]string{"-f", "-", "--images-annotation=false"}, RunOpts{
@@ -261,7 +261,7 @@ func TestImgpkgLockFileNotInOutput(t *testing.T) {
 
 func TestImgpkgLockFileInputSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 images:
@@ -303,7 +303,7 @@ metadata:
 
 func TestImgpkgLockFileOriginsSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 images:
@@ -362,7 +362,7 @@ metadata:
 
 func TestImgpkgLockOutputSuccessfulDigestedImageHasNoOrigins(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 images:

--- a/test/e2e/packaging_test.go
+++ b/test/e2e/packaging_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestPkgUnpkgSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	// redis:5.0.4
 	input := `
@@ -60,7 +60,7 @@ spec:
 
 func TestPkgUnpkgLockSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 apiVersion: kbld.k14s.io/v1alpha1
@@ -123,7 +123,7 @@ overrides:
 
 func TestPkgUnpkgSuccessfulWithForeignLayers(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	// Mongo has 2 foreign layers
 	input := `
@@ -168,7 +168,7 @@ func TestPkgUnpkgSuccessfulWithManyImages(t *testing.T) {
 		return
 	}
 
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 apiVersion: kbld.k14s.io/v1alpha1

--- a/test/e2e/relocate_test.go
+++ b/test/e2e/relocate_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRelocateSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	// redis:5.0.4
 	input := `
@@ -51,7 +51,7 @@ func TestRelocateSuccessfulWithManyImages(t *testing.T) {
 		return
 	}
 
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -125,7 +125,7 @@ spec:
 
 func TestRelocateLockSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 apiVersion: kbld.k14s.io/v1alpha1

--- a/test/e2e/resolve_test.go
+++ b/test/e2e/resolve_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestResolveSuccessful(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -47,7 +47,7 @@ spec:
 
 func TestResolveSuccessfulWithAnnotations(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	// The repetition in this input is so it can test for:
 	// 1) resolving
@@ -95,7 +95,7 @@ spec:
 
 func TestSortAnnotations(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -152,7 +152,7 @@ spec:
 
 func TestResolveInvalidDigest(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -174,7 +174,7 @@ spec:
 
 func TestResolveUnknownImage(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -196,7 +196,7 @@ spec:
 
 func TestResolveWithOverride(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -232,7 +232,7 @@ spec:
 
 func TestResolveWithImageMap(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -281,7 +281,7 @@ spec:
 
 func TestResolveWithImageKeys(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -318,7 +318,7 @@ spec:
 
 func TestResolveWithOverrideMatchingImageRepo(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -353,7 +353,7 @@ spec:
 
 func TestResolveSuccessfulWithSearchRules(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -428,7 +428,7 @@ spec:
 
 func TestResolveSuccessfulWithDuplicateSearchRules(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object
@@ -461,7 +461,7 @@ spec:
 
 func TestResolveSuccessfulWithTagSelection(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	input := `
 kind: Object

--- a/test/e2e/tags_test.go
+++ b/test/e2e/tags_test.go
@@ -17,7 +17,7 @@ import (
 func TestAdditionalImageTags(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, logger}
+	kbld := Kbld{t, env.KbldBinaryPath, logger}
 
 	var published map[string]interface{}
 

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestVersion(t *testing.T) {
 	env := BuildEnv(t)
-	kbld := Kbld{t, env.Namespace, env.KbldBinaryPath, Logger{}}
+	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
 	out, _ := kbld.RunWithOpts([]string{"version"}, RunOpts{})
 


### PR DESCRIPTION
With every file having a build tag, gofmt prints
```
> go: warning: "./test/..." matched no packages
```
If there are any untagged files are there it will pick up all files,
tagged and non:

```
$ go fmt -n  ./test/...
/usr/local/go/bin/gofmt -l -w test/e2e/build_bazel_test.go
test/e2e/build_ko_test.go test/e2e/build_kubectl_buildkit_test.go
test/e2e/build_pack_test.go test/e2e/build_test.go test/e2e/e2e.go
test/e2e/env.go test/e2e/kbld.go test/e2e/lock_output_test.go
test/e2e/packaging_test.go test/e2e/relocate_test.go
test/e2e/resolve_test.go test/e2e/tags_test.go test/e2e/version_test.go
```