### PR TITLE
replace golint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   enable:
     - goheader
-    - golint
+    - revive
     - deadcode
     - unused
   disable-all: true


### PR DESCRIPTION
```
❯ golangci-lint run
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
```