### PR TITLE
Make the Dockerfile.dev quieter

### DIFF
--- a/hack/Dockerfile.dev
+++ b/hack/Dockerfile.dev
@@ -30,6 +30,6 @@ RUN apt-get install google-cloud-cli -y
 RUN git config --global user.email "email@example.com"
 RUN git config --global user.name "Some Person"
 
-RUN curl -sLo "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -P /usr/local/bin/
+RUN curl -sLo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 RUN chmod +x /usr/local/bin/kubectl
 

--- a/hack/Dockerfile.dev
+++ b/hack/Dockerfile.dev
@@ -1,40 +1,35 @@
 FROM golang:1.18
 
 RUN apt-get update -y
-RUN apt-get install wget docker.io apt-transport-https ca-certificates gnupg python -y
+RUN apt-get install docker.io apt-transport-https ca-certificates gnupg python -y
 
 RUN mkdir -p ~/.docker/cli-plugins/
-RUN wget -O- https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+RUN curl -sLo ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64
 RUN chmod +x ~/.docker/cli-plugins/docker-buildx
 
-RUN wget https://github.com/buildpacks/pack/releases/download/v0.8.1/pack-v0.8.1-linux.tgz
-RUN tar -C /usr/local/bin/ -xvf pack-v0.8.1-linux.tgz
+RUN curl -sL https://github.com/buildpacks/pack/releases/download/v0.8.1/pack-v0.8.1-linux.tgz | tar -C /usr/local/bin -xz
 
-RUN wget https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases/download/v0.1.0/linux-refs.tags.v0.1.0.tgz
-RUN tar -C /usr/local/bin/ -xvf linux-refs.tags.v0.1.0.tgz
+RUN curl -sL https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases/download/v0.1.0/linux-refs.tags.v0.1.0.tgz | tar -C /usr/local/bin -xz
 
-RUN wget https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz
-RUN tar -C /usr/local/bin/ -xvf ko_0.8.0_Linux_x86_64.tar.gz
+RUN curl -sL https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | tar -C /usr/local/bin -xz
 
-RUN wget https://github.com/bazelbuild/bazel/releases/download/4.2.0/bazel-4.2.0-linux-x86_64 -P /usr/local/bin/
-RUN chmod +x /usr/local/bin/bazel-4.2.0-linux-x86_64 && /usr/local/bin/bazel-4.2.0-linux-x86_64 && mv /usr/local/bin/bazel-4.2.0-linux-x86_64 /usr/local/bin/bazel
+RUN curl -sLo /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/4.2.0/bazel-4.2.0-linux-x86_64
+RUN chmod +x /usr/local/bin/bazel
 
-RUN wget "https://github.com/vmware-tanzu/carvel-kapp/releases/download/v0.48.0/kapp-linux-amd64" -P /usr/local/bin/
-RUN chmod +x /usr/local/bin/kapp-linux-amd64
-RUN mv /usr/local/bin/kapp-linux-amd64 /usr/local/bin/kapp
+RUN curl -sLo /usr/local/bin/kapp https://github.com/vmware-tanzu/carvel-kapp/releases/download/v0.48.0/kapp-linux-amd64
+RUN chmod +x /usr/local/bin/kapp
 
-RUN wget "https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.41.1/ytt-linux-amd64" -P /usr/local/bin/
-RUN chmod +x /usr/local/bin/ytt-linux-amd64
-RUN mv /usr/local/bin/ytt-linux-amd64 /usr/local/bin/ytt
+RUN curl -sLo /usr/local/bin/ytt https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.41.1/ytt-linux-amd64
+RUN chmod +x /usr/local/bin/ytt
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor > /usr/share/keyrings/cloud.google.gpg
 RUN apt-get update -y
 RUN apt-get install google-cloud-cli -y
 
 RUN git config --global user.email "email@example.com"
 RUN git config --global user.name "Some Person"
 
-RUN wget "https://dl.k8s.io/release/$(wget -q https://dl.k8s.io/release/stable.txt -O -)/bin/linux/amd64/kubectl" -P /usr/local/bin/
+RUN curl -sLo "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -P /usr/local/bin/
 RUN chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
The use of wget in these leaves us with [super noisy output](https://github.com/vmware-tanzu/carvel-kbld/runs/6717365538?check_suite_focus=true#step:4:781) from test runs. It's like 10,000 lines before we even finish building the docker image. I'm biased towards `curl` rather than `wget`, once you learn the basic flags (like `-sLoO`) it's nicer imho