### PR TITLE
Removed/replaced stale images from tests in line 0.32.x

### DIFF
--- a/test/e2e/packaging_test.go
+++ b/test/e2e/packaging_test.go
@@ -227,8 +227,8 @@ overrides:
 - image: index.docker.io/minio/minio@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c
   newImage: index.docker.io/minio/minio@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c
   preresolved: true
-- image: logcache/cf-k8s-logging@sha256:7ee4b08db98627c76091b8b82210eaa9e3a0646db56b534feba7dd0a35c35948
-  newImage: index.docker.io/logcache/cf-k8s-logging@sha256:7ee4b08db98627c76091b8b82210eaa9e3a0646db56b534feba7dd0a35c35948
+- image: index.docker.io/cloudfoundry/cf-k8s-logging@sha256:d8c73e6c87b2a71c8b6798205761bb7870fb2080a4329c4eefb0b4620656eeaa
+  newImage: index.docker.io/cloudfoundry/cf-k8s-logging@sha256:d8c73e6c87b2a71c8b6798205761bb7870fb2080a4329c4eefb0b4620656eeaa
   preresolved: true
 - image: logcache/log-cache-cf-auth-proxy@sha256:6a436c864e5e6d2e153da4776f08fa064021eb365407f5f435a4a9f47afdef3d
   newImage: index.docker.io/logcache/log-cache-cf-auth-proxy@sha256:6a436c864e5e6d2e153da4776f08fa064021eb365407f5f435a4a9f47afdef3d
@@ -239,8 +239,8 @@ overrides:
 - image: logcache/log-cache@sha256:20ffd743bd6b52ff217918b2df3df4886969877feb5565b47248bfefe7b2b210
   newImage: index.docker.io/logcache/log-cache@sha256:20ffd743bd6b52ff217918b2df3df4886969877feb5565b47248bfefe7b2b210
   preresolved: true
-- image: logcache/syslog-server@sha256:623ade911f957d38b36944d9f069feff3d4139ece24557a94d09b28f2efbe3d8
-  newImage: index.docker.io/logcache/syslog-server@sha256:623ade911f957d38b36944d9f069feff3d4139ece24557a94d09b28f2efbe3d8
+- image: index.docker.io/cloudfoundry/syslog-server@sha256:39a386521f94c70071eab4a7fb67cc7e28adba2e2dd8113d6df155c17b19f5a5
+  newImage: index.docker.io/cloudfoundry/syslog-server@sha256:39a386521f94c70071eab4a7fb67cc7e28adba2e2dd8113d6df155c17b19f5a5
   preresolved: true
 - image: oratos/metric-proxy@sha256:a2a0d2201d1a57602a3db337bfa256d6e042dfc09a63ba1b6f39c952847e00dc
   newImage: index.docker.io/oratos/metric-proxy@sha256:a2a0d2201d1a57602a3db337bfa256d6e042dfc09a63ba1b6f39c952847e00dc

--- a/test/e2e/packaging_test.go
+++ b/test/e2e/packaging_test.go
@@ -230,14 +230,14 @@ overrides:
 - image: index.docker.io/cloudfoundry/cf-k8s-logging@sha256:d8c73e6c87b2a71c8b6798205761bb7870fb2080a4329c4eefb0b4620656eeaa
   newImage: index.docker.io/cloudfoundry/cf-k8s-logging@sha256:d8c73e6c87b2a71c8b6798205761bb7870fb2080a4329c4eefb0b4620656eeaa
   preresolved: true
-- image: logcache/log-cache-cf-auth-proxy@sha256:6a436c864e5e6d2e153da4776f08fa064021eb365407f5f435a4a9f47afdef3d
-  newImage: index.docker.io/logcache/log-cache-cf-auth-proxy@sha256:6a436c864e5e6d2e153da4776f08fa064021eb365407f5f435a4a9f47afdef3d
+- image: index.docker.io/cloudfoundry/log-cache-cf-auth-proxy@sha256:f75fc1585dbf869a1a98ee094d334525bb944a07aa0ebe522019c3a479b843de
+  newImage: index.docker.io/cloudfoundry/log-cache-cf-auth-proxy@sha256:f75fc1585dbf869a1a98ee094d334525bb944a07aa0ebe522019c3a479b843de
   preresolved: true
-- image: logcache/log-cache-gateway@sha256:65b34fb624b40a263b6d1be9410ba61d55d515ac340226860d8fd7ef4ac0dbf1
-  newImage: index.docker.io/logcache/log-cache-gateway@sha256:65b34fb624b40a263b6d1be9410ba61d55d515ac340226860d8fd7ef4ac0dbf1
+- image: index.docker.io/cloudfoundry/log-cache-gateway@sha256:51bc54b4a901228537f43efe3b687c3d8c07f49c015775141a0dffa66cd83ec6
+  newImage: index.docker.io/cloudfoundry/log-cache-gateway@sha256:51bc54b4a901228537f43efe3b687c3d8c07f49c015775141a0dffa66cd83ec6
   preresolved: true
-- image: logcache/log-cache@sha256:20ffd743bd6b52ff217918b2df3df4886969877feb5565b47248bfefe7b2b210
-  newImage: index.docker.io/logcache/log-cache@sha256:20ffd743bd6b52ff217918b2df3df4886969877feb5565b47248bfefe7b2b210
+- image: index.docker.io/cloudfoundry/log-cache@sha256:616ce5401945100a84df5380e913d1136f2ed714aa90c78f592839de88928dfb
+  newImage: index.docker.io/cloudfoundry/log-cache@sha256:616ce5401945100a84df5380e913d1136f2ed714aa90c78f592839de88928dfb
   preresolved: true
 - image: index.docker.io/cloudfoundry/syslog-server@sha256:39a386521f94c70071eab4a7fb67cc7e28adba2e2dd8113d6df155c17b19f5a5
   newImage: index.docker.io/cloudfoundry/syslog-server@sha256:39a386521f94c70071eab4a7fb67cc7e28adba2e2dd8113d6df155c17b19f5a5
@@ -250,7 +250,7 @@ overrides:
   preresolved: true
 `
 
-	expectedPackagedSHA := "ebb27484fe5955870f5e8d56b25afb026e90e88b"
+	expectedPackagedSHA := "16ed9a2847ebb5db1cab57bc93817174eed98752"
 
 	path := "/tmp/kbld-test-pkg-unpkg-successful-with-many-images"
 	defer os.RemoveAll(path)

--- a/test/e2e/packaging_test.go
+++ b/test/e2e/packaging_test.go
@@ -218,9 +218,6 @@ overrides:
 - image: gcr.io/cf-build-service-public/kpack/webhook@sha256:c2461ef9634c771f2a06bc0371040b43c9a78dd0e4ac1c9fde3f4525e0ae21f2
   newImage: gcr.io/cf-build-service-public/kpack/webhook@sha256:c2461ef9634c771f2a06bc0371040b43c9a78dd0e4ac1c9fde3f4525e0ae21f2
   preresolved: true
-- image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:de15fb9d960ecd36082550ec7a24dcad12a63f7ca53d110fbb4c9c59eca9b544
-  newImage: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:de15fb9d960ecd36082550ec7a24dcad12a63f7ca53d110fbb4c9c59eca9b544
-  preresolved: true
 - image: index.docker.io/bitnami/postgresql@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
   newImage: index.docker.io/bitnami/postgresql@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
   preresolved: true

--- a/test/e2e/relocate_test.go
+++ b/test/e2e/relocate_test.go
@@ -72,11 +72,11 @@ spec:
 - image: index.docker.io/bitnami/postgresql@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
 - image: index.docker.io/metacontroller/metacontroller@sha256:ad85cb5f5ad9a61a3f38277fed371df43ea0fc55d9073dfa8f4fc2e27c127603
 - image: index.docker.io/minio/minio@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c
-- image: index.docker.io/logcache/cf-k8s-logging@sha256:7ee4b08db98627c76091b8b82210eaa9e3a0646db56b534feba7dd0a35c35948
+- image: index.docker.io/cloudfoundry/cf-k8s-logging@sha256:d8c73e6c87b2a71c8b6798205761bb7870fb2080a4329c4eefb0b4620656eeaa
 - image: index.docker.io/logcache/log-cache-cf-auth-proxy@sha256:6a436c864e5e6d2e153da4776f08fa064021eb365407f5f435a4a9f47afdef3d
 - image: index.docker.io/logcache/log-cache-gateway@sha256:65b34fb624b40a263b6d1be9410ba61d55d515ac340226860d8fd7ef4ac0dbf1
 - image: index.docker.io/logcache/log-cache@sha256:20ffd743bd6b52ff217918b2df3df4886969877feb5565b47248bfefe7b2b210
-- image: index.docker.io/logcache/syslog-server@sha256:623ade911f957d38b36944d9f069feff3d4139ece24557a94d09b28f2efbe3d8
+- image: index.docker.io/cloudfoundry/syslog-server@sha256:39a386521f94c70071eab4a7fb67cc7e28adba2e2dd8113d6df155c17b19f5a5
 - image: index.docker.io/oratos/metric-proxy@sha256:a2a0d2201d1a57602a3db337bfa256d6e042dfc09a63ba1b6f39c952847e00dc
 - image: index.docker.io/prom/statsd-exporter@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc
 `

--- a/test/e2e/relocate_test.go
+++ b/test/e2e/relocate_test.go
@@ -69,7 +69,6 @@ spec:
 - image: index.docker.io/eirini/opi@sha256:2e0b84c5fcb1e6e5cdb07a70210f2e462aa52119f7a330660a7444a938deefbb
 - image: gcr.io/cf-build-service-public/kpack/controller@sha256:1d7d80257e2019a474417ba0c7dcfff5612aeec55e24d91ef7b2e4bd0a521a40
 - image: gcr.io/cf-build-service-public/kpack/webhook@sha256:c2461ef9634c771f2a06bc0371040b43c9a78dd0e4ac1c9fde3f4525e0ae21f2
-- image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:de15fb9d960ecd36082550ec7a24dcad12a63f7ca53d110fbb4c9c59eca9b544
 - image: index.docker.io/bitnami/postgresql@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
 - image: index.docker.io/metacontroller/metacontroller@sha256:ad85cb5f5ad9a61a3f38277fed371df43ea0fc55d9073dfa8f4fc2e27c127603
 - image: index.docker.io/minio/minio@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c

--- a/test/e2e/relocate_test.go
+++ b/test/e2e/relocate_test.go
@@ -73,9 +73,9 @@ spec:
 - image: index.docker.io/metacontroller/metacontroller@sha256:ad85cb5f5ad9a61a3f38277fed371df43ea0fc55d9073dfa8f4fc2e27c127603
 - image: index.docker.io/minio/minio@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c
 - image: index.docker.io/cloudfoundry/cf-k8s-logging@sha256:d8c73e6c87b2a71c8b6798205761bb7870fb2080a4329c4eefb0b4620656eeaa
-- image: index.docker.io/logcache/log-cache-cf-auth-proxy@sha256:6a436c864e5e6d2e153da4776f08fa064021eb365407f5f435a4a9f47afdef3d
-- image: index.docker.io/logcache/log-cache-gateway@sha256:65b34fb624b40a263b6d1be9410ba61d55d515ac340226860d8fd7ef4ac0dbf1
-- image: index.docker.io/logcache/log-cache@sha256:20ffd743bd6b52ff217918b2df3df4886969877feb5565b47248bfefe7b2b210
+- image: index.docker.io/cloudfoundry/log-cache-cf-auth-proxy@sha256:f75fc1585dbf869a1a98ee094d334525bb944a07aa0ebe522019c3a479b843de
+- image: index.docker.io/cloudfoundry/log-cache-gateway@sha256:51bc54b4a901228537f43efe3b687c3d8c07f49c015775141a0dffa66cd83ec6
+- image: index.docker.io/cloudfoundry/log-cache@sha256:616ce5401945100a84df5380e913d1136f2ed714aa90c78f592839de88928dfb
 - image: index.docker.io/cloudfoundry/syslog-server@sha256:39a386521f94c70071eab4a7fb67cc7e28adba2e2dd8113d6df155c17b19f5a5
 - image: index.docker.io/oratos/metric-proxy@sha256:a2a0d2201d1a57602a3db337bfa256d6e042dfc09a63ba1b6f39c952847e00dc
 - image: index.docker.io/prom/statsd-exporter@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc
@@ -103,15 +103,14 @@ spec:
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:2e0b84c5fcb1e6e5cdb07a70210f2e462aa52119f7a330660a7444a938deefbb
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:1d7d80257e2019a474417ba0c7dcfff5612aeec55e24d91ef7b2e4bd0a521a40
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:c2461ef9634c771f2a06bc0371040b43c9a78dd0e4ac1c9fde3f4525e0ae21f2
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:de15fb9d960ecd36082550ec7a24dcad12a63f7ca53d110fbb4c9c59eca9b544
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:ad85cb5f5ad9a61a3f38277fed371df43ea0fc55d9073dfa8f4fc2e27c127603
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:7ee4b08db98627c76091b8b82210eaa9e3a0646db56b534feba7dd0a35c35948
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:6a436c864e5e6d2e153da4776f08fa064021eb365407f5f435a4a9f47afdef3d
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:65b34fb624b40a263b6d1be9410ba61d55d515ac340226860d8fd7ef4ac0dbf1
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:20ffd743bd6b52ff217918b2df3df4886969877feb5565b47248bfefe7b2b210
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:623ade911f957d38b36944d9f069feff3d4139ece24557a94d09b28f2efbe3d8
+- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:d8c73e6c87b2a71c8b6798205761bb7870fb2080a4329c4eefb0b4620656eeaa
+- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:f75fc1585dbf869a1a98ee094d334525bb944a07aa0ebe522019c3a479b843de
+- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:51bc54b4a901228537f43efe3b687c3d8c07f49c015775141a0dffa66cd83ec6
+- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:616ce5401945100a84df5380e913d1136f2ed714aa90c78f592839de88928dfb
+- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:39a386521f94c70071eab4a7fb67cc7e28adba2e2dd8113d6df155c17b19f5a5
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:a2a0d2201d1a57602a3db337bfa256d6e042dfc09a63ba1b6f39c952847e00dc
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc
 `)


### PR DESCRIPTION
**Issue:**
Test `TestRelocateSuccessfulWithManyImages ` and  `TestPkgUnpkgSuccessfulWithManyImages` are failing with error: 

```
 kbld: Error: Collecting packaging metadata:
          Working with gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:de15fb9d960ecd36082550ec7a24dcad12a63f7ca53d110fbb4c9c59eca9b544:
            Encountered an error most likely because this image is in Docker Registry v1 format; only v2 or OCI image format is supported (underlying error: GET https://gcr.io/v2/cf-networking-images/cf-k8s-networking/cfroutesync/manifests/sha256:de15fb9d960ecd36082550ec7a24dcad12a63f7ca53d110fbb4c9c59eca9b544: MANIFEST_UNKNOWN: Failed to fetch "sha256:de15fb9d960ecd36082550ec7a24dcad12a63f7ca53d110fbb4c9c59eca9b544" from request "/v2/cf-networking-images/cf-k8s-networking/cfroutesync/manifests/sha256:de15fb9d960ecd36082550ec7a24dcad12a63f7ca53d110fbb4c9c59eca9b544".
```
Seems v1 format is deprecated and now  it trying fetch image with format v2 which is not found.

**Fix:**
Removed/replaced stale images from tests