### PR TITLE
Bumping go version to v1.19.6 in 0.35.x line

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.5"
+          go-version: "1.19.6"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.5
+          go-version: 1.19.6
 
       - name: Run GoReleaser
         # GoReleaser v2.5.0

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -18,13 +18,14 @@ jobs:
   test-all:
     name: Test GH
     runs-on: ubuntu-latest
+    environment: DockerHub E2E
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
         go-version: "1.19.6"
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/github.com/${{ github.repository }}
         fetch-depth: 0

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: carvel-dev/kbld
       tool: kbld
-      goVersion: 1.19.5
+      goVersion: 1.19.6
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/hack/Dockerfile.dev
+++ b/hack/Dockerfile.dev
@@ -33,3 +33,4 @@ RUN git config --global user.name "Some Person"
 RUN curl -sLo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 RUN chmod +x /usr/local/bin/kubectl
 
+COPY ./ /go/src/kbld/

--- a/hack/test-all-locally.sh
+++ b/hack/test-all-locally.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e -x -u
 
-SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
-
 go clean -testcache
 ./hack/build.sh
 export KBLD_BINARY_PATH="${KBLD_BINARY_PATH:-$PWD/kbld}"
@@ -15,12 +13,12 @@ apiVersion: kbld.k14s.io/v1alpha1
 kind: Config
 sources:
 - image: test-dependencies
-  path: hack/
+  path: .
   docker:
     build:
       pull: true
       noCache: false
-      file: Dockerfile.dev
+      file: hack/Dockerfile.dev
 EOF
 }
 
@@ -41,7 +39,6 @@ docker run \
 -v ~/.config:/root/.config \
 -v ~/.minikube:"$HOME/.minikube" \
 -v ~/.kube:/root/.kube \
--v ${SCRIPT_DIR}/..:/go/src/kbld \
 -v /etc/docker/:/host-etc-docker \
 --workdir /go/src/kbld \
 -i -a STDOUT -a STDERR \


### PR DESCRIPTION
- Bumping go version to v1.19.6 in 0.35.x line
- docker copy instead of mount to resolve dubious ownership issue (as test cases are failing due to this cherry-picked from develop)