### PR TITLE
Bumping to go 1.20.3 and golangci-lint changes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.50.1
+          version: v1.52.2
           args: -v
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.6
+          go-version: 1.20.3
       - name: Retrieve version
         run: |
           echo "TAG_NAME=$(echo ${{ github.ref }}  | grep -Eo 'v[0-9].*')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -21,11 +21,11 @@ jobs:
     environment: DockerHub E2E
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: "1.19.6"
+        go-version: "1.20.3"
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.3.0
       with:
         path: src/github.com/${{ github.repository }}
         fetch-depth: 0

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: carvel-dev/kbld
       tool: kbld
-      goVersion: 1.19.6
+      goVersion: 1.20.3
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/carvel-kbld
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65

--- a/hack/Dockerfile.dev
+++ b/hack/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.20
 
 RUN apt-get update -y
 RUN apt-get install docker.io apt-transport-https ca-certificates gnupg python -y

--- a/pkg/kbld/cmd/resolve.go
+++ b/pkg/kbld/cmd/resolve.go
@@ -178,7 +178,7 @@ func (o *ResolveOptions) resolveImages(imageURLs *UnprocessedImageURLs, imgFacto
 
 func (o *ResolveOptions) updateRefsInResources(nonConfigRs []ctlres.Resource,
 	conf ctlconf.Conf, resolvedImages *ProcessedImages,
-	imgFactory ctlimg.Factory) ([][]byte, error) {
+	_ ctlimg.Factory) ([][]byte, error) {
 
 	var errs []error
 	var resBss [][]byte

--- a/pkg/kbld/search/image_refs.go
+++ b/pkg/kbld/search/image_refs.go
@@ -189,7 +189,7 @@ type tmpRefMatcher struct {
 
 var _ Matcher = tmpRefMatcher{}
 
-func (m tmpRefMatcher) Matches(key ctlres.Path, value interface{}) (bool, ctlconf.SearchRuleUpdateStrategy) {
+func (m tmpRefMatcher) Matches(_ ctlres.Path, value interface{}) (bool, ctlconf.SearchRuleUpdateStrategy) {
 	if valStr, ok := value.(string); ok {
 		return strings.HasPrefix(valStr, m.prefix), (ctlconf.SearchRule{}).UpdateStrategyWithDefaults()
 	}


### PR DESCRIPTION
Bumping to go 1.20.3 for CVE fixes