### PR TITLE
Remove go fmt and vendor from binary build scripts in 0.35.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,15 @@ jobs:
         id: version
 
       - name: Run GoReleaser
-        # GoReleaser v2.5.0
-        uses: goreleaser/goreleaser-action@5e15885530fb01d81d1f24e8a6f54ebbd0fed7eb
+        # GoReleaser v4.2.0
+        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          version: 0.184.0
-          args: release --rm-dist --debug
+          version: 1.16.2
+          args: release --clean --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.TAG_NAME }}
 
       - uses: actions/github-script@v4
         id: get-checksums-from-draft-release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,5 @@
 # This is an example .goreleaser.yml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
-before:
-  hooks:
-    - go mod tidy
 builds:
   - env:
       - CGO_ENABLED=0

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -8,10 +8,6 @@ function get_latest_git_tag {
 
 VERSION="${1:-`get_latest_git_tag`}"
 
-go fmt ./cmd/... ./pkg/... ./test/...
-go mod vendor
-go mod tidy
-
 # makes builds reproducible
 export CGO_ENABLED=0
 LDFLAGS="-X github.com/vmware-tanzu/carvel-kbld/pkg/kbld/version.Version=$VERSION"


### PR DESCRIPTION
Bump version of goreleaser to latest