### PR TITLE
[0.37.x] Fixing CVE by updating go version to 1.22.3

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.22.2"
+          go-version: "1.22.3"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.22.2
+          go-version: 1.22.3
       - name: Retrieve version
         run: |
           echo "TAG_NAME=$(echo ${{ github.ref }}  | grep -Eo 'v[0-9].*')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: DockerHub E2E
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@v1.3.0
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: true
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: "1.22.2"
+        go-version: "1.22.3"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3.3.0
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: carvel-dev/kbld
       tool: kbld
-      goVersion: 1.22.2
+      goVersion: 1.22.3
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/vmware-tanzu/carvel-kbld
 
 go 1.22
 
+toolchain go1.22.3
+
 require (
 	github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65
 	github.com/cppforlife/go-cli-ui v0.0.0-20220428182907-73db60c7611a


### PR DESCRIPTION
Fixing CVE by updating go version to 1.22.3