### PR TITLE
Lower case the repositories when pushing to registry

### DIFF
--- a/pkg/kbld/builder/docker/docker.go
+++ b/pkg/kbld/builder/docker/docker.go
@@ -6,6 +6,7 @@ package docker
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -192,6 +193,12 @@ func (d Docker) Push(tmpRef TmpRef, imageDst string) (ImageDigest, error) {
 		imageDstTagged, err = regname.NewTag(imageDst+":"+imageDstTag, regname.WeakValidation)
 		if err != nil {
 			return ImageDigest{}, fmt.Errorf("Generating image dst tag '%s': %s", imageDst, err)
+		}
+	} else if errors.Is(err, &regname.ErrBadName{}) {
+		imageDstTagged, err = regname.NewTag(strings.ToLower(imageDst))
+		if err != nil {
+			err := fmt.Errorf("Lower casing repository still failed: %s", err)
+			return ImageDigest{}, err
 		}
 	}
 

--- a/pkg/kbld/builder/docker/docker.go
+++ b/pkg/kbld/builder/docker/docker.go
@@ -182,6 +182,7 @@ func (d Docker) Push(tmpRef TmpRef, imageDst string) (ImageDigest, error) {
 	// TODO we are technically polluting registry with new tags.
 	// Unfortunately we do not know digest upfront so cannot use kbld-sha256-... format.
 	imageDstTagged, err := regname.NewTag(imageDst, regname.WeakValidation)
+	badNameErr := (*regname.ErrBadName)(nil)
 	if err == nil {
 		randSuffix, err := tb.RandomStr50()
 		if err != nil {
@@ -192,12 +193,15 @@ func (d Docker) Push(tmpRef TmpRef, imageDst string) (ImageDigest, error) {
 
 		imageDstTagged, err = regname.NewTag(imageDst+":"+imageDstTag, regname.WeakValidation)
 		if err != nil {
-			return ImageDigest{}, fmt.Errorf("Generating image dst tag '%s': %s", imageDst, err)
+			return ImageDigest{}, fmt.Errorf(
+				"Generating image dst tag '%s': %s", imageDst, err)
 		}
-	} else if badNameErr := (*regname.ErrBadName)(nil); errors.As(err, &badNameErr) {
+	} else if errors.As(err, &badNameErr) {
 		imageDstTagged, err = regname.NewTag(lowerCaseRepository(imageDst))
 		if err != nil {
-			return ImageDigest{}, fmt.Errorf("Lower casing repository '%s' still failed: %w", imageDst, err)
+			newError := fmt.Errorf(
+				"Lower casing repository '%s' still failed: %w", imageDst, err)
+			return ImageDigest{}, newError
 		}
 	}
 
@@ -337,7 +341,8 @@ func (d Docker) Inspect(ref string) (InspectData, error) {
 // while preserving the tag (tags are case-sensitive in Docker registries).
 func lowerCaseRepository(ref string) string {
 	// Walk slash-separated segments to identify the final component.
-	// The tag separator ':' can only appear in the last segment, never in the host.
+	// The tag separator ':' can only appear in the last segment,
+	// never in the host.
 	var prefix string
 	tail := ref
 	for {

--- a/pkg/kbld/builder/docker/docker.go
+++ b/pkg/kbld/builder/docker/docker.go
@@ -194,11 +194,10 @@ func (d Docker) Push(tmpRef TmpRef, imageDst string) (ImageDigest, error) {
 		if err != nil {
 			return ImageDigest{}, fmt.Errorf("Generating image dst tag '%s': %s", imageDst, err)
 		}
-	} else if errors.Is(err, &regname.ErrBadName{}) {
-		imageDstTagged, err = regname.NewTag(strings.ToLower(imageDst))
+	} else if badNameErr := (*regname.ErrBadName)(nil); errors.As(err, &badNameErr) {
+		imageDstTagged, err = regname.NewTag(lowerCaseRepository(imageDst))
 		if err != nil {
-			err := fmt.Errorf("Lower casing repository still failed: %s", err)
-			return ImageDigest{}, err
+			return ImageDigest{}, fmt.Errorf("Lower casing repository '%s' still failed: %w", imageDst, err)
 		}
 	}
 
@@ -332,4 +331,27 @@ func (d Docker) Inspect(ref string) (InspectData, error) {
 	}
 
 	return data[0], nil
+}
+
+// lowerCaseRepository lowercases the registry and repository portions of ref
+// while preserving the tag (tags are case-sensitive in Docker registries).
+func lowerCaseRepository(ref string) string {
+	// Walk slash-separated segments to identify the final component.
+	// The tag separator ':' can only appear in the last segment, never in the host.
+	var prefix string
+	tail := ref
+	for {
+		seg, rest, found := strings.Cut(tail, "/")
+		if !found {
+			break
+		}
+		prefix += seg + "/"
+		tail = rest
+	}
+	// tail is now the final path segment (e.g. "myimage" or "myimage:mytag")
+	name, tag, hasTag := strings.Cut(tail, ":")
+	if !hasTag {
+		return strings.ToLower(ref)
+	}
+	return strings.ToLower(prefix+name) + ":" + tag
 }

--- a/test/e2e/relocate_test.go
+++ b/test/e2e/relocate_test.go
@@ -68,8 +68,6 @@ spec:
 - image: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
 - image: index.docker.io/istio/sidecar_injector@sha256:ba446f8cf98bafdad4514fd492432dd180243cbc55a0b9c6bebfe31cb169033d
 - image: index.docker.io/eirini/opi@sha256:2e0b84c5fcb1e6e5cdb07a70210f2e462aa52119f7a330660a7444a938deefbb
-- image: ghcr.io/buildpacks-community/kpack/controller@sha256:80e71f484f0aa5f54eb549f5d5e015ac5373c9bc616f12891d676a7e1dfb80bd
-- image: ghcr.io/buildpacks-community/kpack/webhook@sha256:43fc8706c744f4686cc81d10dddc0ab9cd222d7d885904f3d6cc9c184a73cd84
 - image: index.docker.io/bitnami/postgresql@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
 - image: index.docker.io/metacontroller/metacontroller@sha256:ad85cb5f5ad9a61a3f38277fed371df43ea0fc55d9073dfa8f4fc2e27c127603
 - image: index.docker.io/minio/minio@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c
@@ -101,8 +99,6 @@ spec:
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:ba446f8cf98bafdad4514fd492432dd180243cbc55a0b9c6bebfe31cb169033d
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:2e0b84c5fcb1e6e5cdb07a70210f2e462aa52119f7a330660a7444a938deefbb
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:80e71f484f0aa5f54eb549f5d5e015ac5373c9bc616f12891d676a7e1dfb80bd
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:43fc8706c744f4686cc81d10dddc0ab9cd222d7d885904f3d6cc9c184a73cd84
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:ad85cb5f5ad9a61a3f38277fed371df43ea0fc55d9073dfa8f4fc2e27c127603
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c


### PR DESCRIPTION
Some registries allow the URL's provided to have uppercase characters despite the convention disctating that only lower case characters, numbers and . or / can be present in the namespace.