### PR TITLE
test: fix e2e tests with updated image references

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -114,7 +114,7 @@ overrides:
 		StdinReader: strings.NewReader(input),
 	})
 
-	out = strings.Replace(out, regexp.MustCompile("sha256:[a-z0-9]{64}").FindString(out), "SHA256-REPLACED", -1)
+	out = regexp.MustCompile("sha256:[a-z0-9]{64}").ReplaceAllString(out, "SHA256-REPLACED")
 
 	expectedOut := env.WithRegistries(`---
 kind: Object

--- a/test/e2e/packaging_test.go
+++ b/test/e2e/packaging_test.go
@@ -211,11 +211,11 @@ overrides:
 - image: eirini/opi@sha256:2e0b84c5fcb1e6e5cdb07a70210f2e462aa52119f7a330660a7444a938deefbb
   newImage: index.docker.io/eirini/opi@sha256:2e0b84c5fcb1e6e5cdb07a70210f2e462aa52119f7a330660a7444a938deefbb
   preresolved: true
-- image: gcr.io/cf-build-service-public/kpack/controller@sha256:1d7d80257e2019a474417ba0c7dcfff5612aeec55e24d91ef7b2e4bd0a521a40
-  newImage: gcr.io/cf-build-service-public/kpack/controller@sha256:1d7d80257e2019a474417ba0c7dcfff5612aeec55e24d91ef7b2e4bd0a521a40
+- image: ghcr.io/buildpacks-community/kpack/controller@sha256:80e71f484f0aa5f54eb549f5d5e015ac5373c9bc616f12891d676a7e1dfb80bd
+  newImage: ghcr.io/buildpacks-community/kpack/controller@sha256:80e71f484f0aa5f54eb549f5d5e015ac5373c9bc616f12891d676a7e1dfb80bd
   preresolved: true
-- image: gcr.io/cf-build-service-public/kpack/webhook@sha256:c2461ef9634c771f2a06bc0371040b43c9a78dd0e4ac1c9fde3f4525e0ae21f2
-  newImage: gcr.io/cf-build-service-public/kpack/webhook@sha256:c2461ef9634c771f2a06bc0371040b43c9a78dd0e4ac1c9fde3f4525e0ae21f2
+- image: ghcr.io/buildpacks-community/kpack/webhook@sha256:43fc8706c744f4686cc81d10dddc0ab9cd222d7d885904f3d6cc9c184a73cd84
+  newImage: ghcr.io/buildpacks-community/kpack/webhook@sha256:43fc8706c744f4686cc81d10dddc0ab9cd222d7d885904f3d6cc9c184a73cd84
   preresolved: true
 - image: index.docker.io/bitnami/postgresql@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
   newImage: index.docker.io/bitnami/postgresql@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
@@ -249,7 +249,7 @@ overrides:
   preresolved: true
 `
 
-	expectedPackagedSHA := "e2c66f42fdac6993741440ba157fe4fb3f505eb3"
+	expectedPackagedSHA := "ca02098b7f6cee61836119233e3b43d1a92083b4"
 
 	path := "/tmp/kbld-test-pkg-unpkg-successful-with-many-images"
 	defer os.RemoveAll(path)

--- a/test/e2e/relocate_test.go
+++ b/test/e2e/relocate_test.go
@@ -68,8 +68,8 @@ spec:
 - image: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
 - image: index.docker.io/istio/sidecar_injector@sha256:ba446f8cf98bafdad4514fd492432dd180243cbc55a0b9c6bebfe31cb169033d
 - image: index.docker.io/eirini/opi@sha256:2e0b84c5fcb1e6e5cdb07a70210f2e462aa52119f7a330660a7444a938deefbb
-- image: gcr.io/cf-build-service-public/kpack/controller@sha256:1d7d80257e2019a474417ba0c7dcfff5612aeec55e24d91ef7b2e4bd0a521a40
-- image: gcr.io/cf-build-service-public/kpack/webhook@sha256:c2461ef9634c771f2a06bc0371040b43c9a78dd0e4ac1c9fde3f4525e0ae21f2
+- image: ghcr.io/buildpacks-community/kpack/controller@sha256:80e71f484f0aa5f54eb549f5d5e015ac5373c9bc616f12891d676a7e1dfb80bd
+- image: ghcr.io/buildpacks-community/kpack/webhook@sha256:43fc8706c744f4686cc81d10dddc0ab9cd222d7d885904f3d6cc9c184a73cd84
 - image: index.docker.io/bitnami/postgresql@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
 - image: index.docker.io/metacontroller/metacontroller@sha256:ad85cb5f5ad9a61a3f38277fed371df43ea0fc55d9073dfa8f4fc2e27c127603
 - image: index.docker.io/minio/minio@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c
@@ -101,8 +101,8 @@ spec:
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:ba446f8cf98bafdad4514fd492432dd180243cbc55a0b9c6bebfe31cb169033d
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:2e0b84c5fcb1e6e5cdb07a70210f2e462aa52119f7a330660a7444a938deefbb
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:1d7d80257e2019a474417ba0c7dcfff5612aeec55e24d91ef7b2e4bd0a521a40
-- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:c2461ef9634c771f2a06bc0371040b43c9a78dd0e4ac1c9fde3f4525e0ae21f2
+- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:80e71f484f0aa5f54eb549f5d5e015ac5373c9bc616f12891d676a7e1dfb80bd
+- image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:43fc8706c744f4686cc81d10dddc0ab9cd222d7d885904f3d6cc9c184a73cd84
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:9762d9a80b90a5efe299d4848057ac5c45fb384570b36f60aad38fe2b1704bd6
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:ad85cb5f5ad9a61a3f38277fed371df43ea0fc55d9073dfa8f4fc2e27c127603
 - image: index.docker.io/*username*/kbld-test-relocate-successful-with-many-images@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c

--- a/test/e2e/resolve_test.go
+++ b/test/e2e/resolve_test.go
@@ -496,25 +496,25 @@ func TestResolveSuccessfulWithPlatformSelectionConfig(t *testing.T) {
 	input := `
 kind: Object
 spec:
-- image: nginx-arm64
-- image: nginx-amd64
-- image: nginx-all
+- image: pause-arm64
+- image: pause-amd64
+- image: pause-all
 ---
 apiVersion: kbld.k14s.io/v1alpha1
 kind: ImageOverrides
 overrides:
-- image: nginx-arm64
-  newImage: index.docker.io/library/nginx:1.14.2
+- image: pause-arm64
+  newImage: gcr.io/google-containers/pause:3.2
   platformSelection:
     os: linux
     architecture: arm64
-- image: nginx-amd64
-  newImage: index.docker.io/library/nginx:1.14.2
+- image: pause-amd64
+  newImage: gcr.io/google-containers/pause:3.2
   platformSelection:
     os: linux
     architecture: amd64
-- image: nginx-all
-  newImage: index.docker.io/library/nginx:1.14.2
+- image: pause-all
+  newImage: gcr.io/google-containers/pause:3.2
 `
 
 	out, _ := kbld.RunWithOpts([]string{"-f", "-"}, RunOpts{
@@ -528,31 +528,31 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - resolved:
-            tag: 1.14.2
-            url: index.docker.io/library/nginx:1.14.2
-        - platformSelected:
-            architecture: amd64
-            index: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
-            os: linux
-        url: index.docker.io/library/nginx@sha256:706446e9c6667c0880d5da3f39c09a6c7d2114f5a5d6b74a2fafd24ae30d2078
-      - origins:
-        - resolved:
-            tag: 1.14.2
-            url: index.docker.io/library/nginx:1.14.2
+            tag: "3.2"
+            url: gcr.io/google-containers/pause:3.2
         - platformSelected:
             architecture: arm64
-            index: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+            index: gcr.io/google-containers/pause@sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f
             os: linux
-        url: index.docker.io/library/nginx@sha256:d58b3e481b8588c080b42e5d7427f2c2061decbf9194f06e2adce641822e282a
+        url: gcr.io/google-containers/pause@sha256:31d3efd12022ffeffb3146bc10ae8beb890c80ed2f07363515580add7ed47636
       - origins:
         - resolved:
-            tag: 1.14.2
-            url: index.docker.io/library/nginx:1.14.2
-        url: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+            tag: "3.2"
+            url: gcr.io/google-containers/pause:3.2
+        - platformSelected:
+            architecture: amd64
+            index: gcr.io/google-containers/pause@sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f
+            os: linux
+        url: gcr.io/google-containers/pause@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108
+      - origins:
+        - resolved:
+            tag: "3.2"
+            url: gcr.io/google-containers/pause:3.2
+        url: gcr.io/google-containers/pause@sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f
 spec:
-- image: index.docker.io/library/nginx@sha256:d58b3e481b8588c080b42e5d7427f2c2061decbf9194f06e2adce641822e282a
-- image: index.docker.io/library/nginx@sha256:706446e9c6667c0880d5da3f39c09a6c7d2114f5a5d6b74a2fafd24ae30d2078
-- image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+- image: gcr.io/google-containers/pause@sha256:31d3efd12022ffeffb3146bc10ae8beb890c80ed2f07363515580add7ed47636
+- image: gcr.io/google-containers/pause@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108
+- image: gcr.io/google-containers/pause@sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f
 `
 
 	require.YAMLEq(t, expectedOut, out)


### PR DESCRIPTION
This PR updates some image references that aren't available anymore. In particular, it fixes errors like:

```
        kbld: Error: Collecting packaging metadata:
          Working with gcr.io/cf-build-service-public/kpack/controller@sha256:1d7d80257e2019a474417ba0c7dcfff5612aeec55e24d91ef7b2e4bd0a521a40:
            GET https://gcr.io/v2/token?scope=repository%3Acf-build-service-public%2Fkpack%2Fcontroller%3Apull&service=gcr.io: unexpected status code 412 Precondition Failed:
              Container Registry is deprecated and shutting down, please use the auto migration tool to migrate to Artifact Registry (gcloud artifacts docker upgrade migrate --projects='cf-build-service-public'). For more details see: https://cloud.google.com/artifact-registry/docs/transition/auto-migrate-gcr-ar
```

Ref: https://github.com/carvel-dev/kbld/actions/runs/18490236576/job/52681935247?pr=560#step:6:1469

Additionally, it fixes the following failing test:

```
=== RUN   TestDockerBuildAndPushSuccessful
Running 'kbld -f - --images-annotation=false --yes'...
    build_test.go:128: Expected >>>---
        kind: Object
        spec:
        - image: 192.168.49.2:30777/minikube-tests/kbld-e2e-tests-build@SHA256-REPLACED
        - image: 192.168.49.2:30777/minikube-tests/kbld-e2e-tests-build@sha256:6c98f836379961592129df14dcc931f3823e395f54bc2b364b2a000797d80dca
        - image: 192.168.49.2:30777/minikube-tests/kbld-e2e-tests-build@sha256:fb3c1bcf5811620737672850b1625b48adb472a9051c007ee5f10a04c062bf56
        <<< to match >>>---
        kind: Object
        spec:
        - image: 192.168.49.2:30777/minikube-tests/kbld-e2e-tests-build@SHA256-REPLACED
        - image: 192.168.49.2:30777/minikube-tests/kbld-e2e-tests-build@SHA256-REPLACED
        - image: 192.168.49.2:30777/minikube-tests/kbld-e2e-tests-build@SHA256-REPLACED
        <<<
--- FAIL: TestDockerBuildAndPushSuccessful (0.93s)
```

I don't know how this test worked in the past, as the corresponding code was replacing only the first occurrence of the regexp. Maybe in the past all digests were the same – in this case that code could work.