### PR TITLE
fix: trim 'v' prefix from kbld version string

### DIFF
--- a/pkg/kbld/version/version.go
+++ b/pkg/kbld/version/version.go
@@ -5,6 +5,7 @@ package version
 
 import (
 	"runtime/debug"
+	"strings"
 )
 
 var (
@@ -33,7 +34,10 @@ func version() string {
 	// Anything else.
 	for _, dep := range info.Deps {
 		if dep.Path == moduleName {
-			return dep.Version
+			// The minimumRequiredVersion field in kbld config is populated
+			// from this version. Since the validation logic doesn't allow
+			// minimumRequiredVersion to have a 'v' prefix, we remove it here.
+			return strings.TrimPrefix(dep.Version, "v")
 		}
 	}
 


### PR DESCRIPTION
When kbld is used as a Go module dependency, the version string is taken from
the Go module version, which currently includes a 'v' prefix (e.g., 'v0.46.0').
The validation logic for the kbld config's `minimumRequiredVersion` field does not
accept this 'v' prefix, leading to validation errors like the following:

```
  kbld: Error: Validating config/ (kbld.k14s.io/v1alpha1) cluster:
    Validating minimum version:
      Must not have prefix 'v' (e.g. '0.8.0')
```

This change trims the 'v' prefix from the version string returned from
dependencies.
