### PR TITLE
Bump Golang to 1.25.5 to fix CVEs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.4
           args: -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: '0'
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "2"
 linters:
   enable:
     - goheader

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,19 +4,17 @@ linters:
     - goheader
     - revive
     - unused
-  disable-all: true
-# all available settings of specific linters
-linters-settings:
-  goheader:
-    values:
-      regexp:
-        copyright-year: 20[0-9][0-9]
-    template-path: code-header-template.txt
-  revive:
-    enable-all-rules: true
-    rules:
-    - name: dot-imports
-      disabled: true
+  settings:
+    goheader:
+      values:
+        regexp:
+          copyright-year: 20[0-9][0-9]
+      template-path: code-header-template.txt
+    revive:
+      enable-all-rules: true
+      rules:
+      - name: dot-imports
+        disabled: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/kbld
 
-go 1.24.9
+go 1.25.5
 
 require (
 	carvel.dev/imgpkg v0.47.0

--- a/hack/Dockerfile.dev
+++ b/hack/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.3
+FROM golang:1.25.5
 
 RUN apt-get update -y
 RUN apt-get install docker.io apt-transport-https ca-certificates gnupg python-is-python3 -y


### PR DESCRIPTION
Bumping Golang to 1.25.5 in order to fix the following CVEs:

```

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-61729 │ HIGH     │ fixed  │ v1.25.4           │ 1.24.11, 1.25.5 │ crypto/x509: Excessive resource consumption when printing   │
│         │                │          │        │                   │                 │ error string for host certificate validation...             │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-61729                  │
│         ├────────────────┼──────────┤        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2025-61727 │ MEDIUM   │        │                   │                 │ golang: crypto/x509: excluded subdomain constraint does not │
│         │                │          │        │                   │                 │ restrict wildcard SANs                                      │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-61727                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘
```