### PR TITLE
Bump golang 1.25.7 and Latest Carvel tools

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -18,6 +18,8 @@ jobs:
   test-all:
     name: Test GH
     runs-on: ubuntu-latest
+    env:
+      DOCKER_API_VERSION: "1.52"
     environment: DockerHub E2E
     steps:
     - name: Free Disk Space (Ubuntu)
@@ -40,6 +42,22 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         only: ytt, kapp
+        
+    - name: Check Default Docker Version
+      run: |
+        echo "=== Version before update ==="
+        docker version || echo "docker-version not found"
+
+    - name: Install Latest Docker Compose
+      uses: docker/setup-compose-action@v1
+      with:
+        version: latest
+
+    - name: Verify New Docker Version
+      run: |
+        echo "=== Version after update ==="
+        docker version
+    
     - name: Run Tests
       env:
         DOCKERHUB_USERNAME: k8slt
@@ -50,6 +68,7 @@ jobs:
         minikube start --driver=docker --wait=all --mount --mount-string "$HOME:$HOME"
         eval $(minikube docker-env --shell=bash)
 
+        export DOCKER_API_VERSION=1.52
         # when this workflow runs of a pull request based on a fork, secrets are unavailable
         # https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow
         if [[ "${DOCKERHUB_ACCESS_TOKEN}" != "" ]]; then

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/cli v28.2.2+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
+	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module carvel.dev/kbld
 
-go 1.25.6
+go 1.25.7
 
 require (
-	carvel.dev/imgpkg v0.47.1
-	carvel.dev/vendir v0.45.1
+	carvel.dev/imgpkg v0.47.2
+	carvel.dev/vendir v0.45.2
 	github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65
 	github.com/cppforlife/go-cli-ui v0.0.0-20220428182907-73db60c7611a
 	github.com/google/go-containerregistry v0.20.6

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/docker/cli v28.2.2+incompatible h1:qzx5BNUDFqlvyq4AHzdNB7gSyVTmU4cgsy
 github.com/docker/cli v28.2.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
+github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-carvel.dev/imgpkg v0.47.1 h1:5hJu20JeAr3HGGRCDi2ydlKVEhhF6bq0EebdB9Eql2I=
-carvel.dev/imgpkg v0.47.1/go.mod h1:f/LUtEuUHTdAeFfDcRa2MTwfXbQe6cq+kzzlQF0In6w=
-carvel.dev/vendir v0.45.1 h1:vVZjAEZz/j1HVLfm1/avlRF235skXpHFrx77GDqJMgo=
-carvel.dev/vendir v0.45.1/go.mod h1:t7/ulJsKBhyOAFyJUt3m1JyIdyvZsAh8eLGr0n1MiLk=
+carvel.dev/imgpkg v0.47.2 h1:rEqC/Saf3PHmHEhaJMcqZLjatALTPD9VmBXuUYqPaGk=
+carvel.dev/imgpkg v0.47.2/go.mod h1:3vIZkREPq+i7s8eloLEv5+t+LzzC49uv9xeh+KLADdk=
+carvel.dev/vendir v0.45.2 h1:oaOqEVgw/z4AZgCvZPgfY+JUFf3YGJSUTH2QLTyIV5A=
+carvel.dev/vendir v0.45.2/go.mod h1:R6wZyF61/mbTe4VpXBky0FiDNoCSIND+/LQvUJkkQVQ=
 github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4 h1:F4rZiMGZyC66j9VB7doVOE4tFHF1yNEihQlOuht4jmM=
 github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4/go.mod h1:4cFTBLAr/U11ykiEEQMccu4uJ1i0GS+atJmeETHCFtI=
 github.com/containerd/stargz-snapshotter/estargz v0.16.3 h1:7evrXtoh1mSbGj/pfRccTampEyKpjpOnS3CyiV1Ebr8=

--- a/hack/Dockerfile.dev
+++ b/hack/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.6
+FROM golang:1.25.7
 
 RUN apt-get update -y
 RUN apt-get install docker.io apt-transport-https ca-certificates gnupg python-is-python3 -y

--- a/pkg/kbld/builder/docker/docker.go
+++ b/pkg/kbld/builder/docker/docker.go
@@ -105,9 +105,12 @@ func (d Docker) Build(image, directory string, opts BuildOpts) (TmpRef, error) {
 		cmd.Stdout = io.MultiWriter(&stdoutBuf, prefixedLogger)
 		cmd.Stderr = io.MultiWriter(&stderrBuf, prefixedLogger)
 
+		cmdEnv := os.Environ()
+		cmdEnv = append(cmdEnv, "DOCKER_API_VERSION=1.52")
 		if opts.Buildkit != nil {
-			cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+			cmdEnv = append(cmdEnv, "DOCKER_BUILDKIT=1")
 		}
+		cmd.Env = cmdEnv
 
 		err := cmd.Run()
 		if err != nil {

--- a/pkg/kbld/builder/kubectlbuildkit/kubectl_buildkit.go
+++ b/pkg/kbld/builder/kubectlbuildkit/kubectl_buildkit.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 
 	ctlb "carvel.dev/kbld/pkg/kbld/builder"
 	ctlconf "carvel.dev/kbld/pkg/kbld/config"
@@ -86,6 +88,15 @@ func (d KubectlBuildkit) BuildAndPush(image, directory string,
 
 	cmd := exec.Command("kubectl", cmdArgs...)
 	cmd.Dir = directory
+	var newEnv []string
+	for _, envVar := range os.Environ() {
+		if !strings.HasPrefix(envVar, "DOCKER_API_VERSION=") {
+			newEnv = append(newEnv, envVar)
+		}
+	}
+
+	newEnv = append(os.Environ(), "DOCKER_API_VERSION=1.52")
+	cmd.Env = newEnv
 	cmd.Stdout = io.MultiWriter(&stdoutBuf, prefixedLogger)
 	cmd.Stderr = io.MultiWriter(&stderrBuf, prefixedLogger)
 

--- a/pkg/kbld/builder/pack/pack.go
+++ b/pkg/kbld/builder/pack/pack.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 
@@ -72,6 +73,7 @@ func (d Pack) Build(image, directory string, opts PackBuildOpts) (ctlbdk.TmpRef,
 
 		cmd := exec.Command("pack", cmdArgs...)
 		cmd.Dir = directory
+		cmd.Env = append(os.Environ(), "DOCKER_API_VERSION=1.52")
 		cmd.Stdout = io.MultiWriter(&stdoutBuf, prefixedLogger)
 		cmd.Stderr = io.MultiWriter(&stderrBuf, prefixedLogger)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,8 @@
-# carvel.dev/imgpkg v0.47.1
-## explicit; go 1.25.6
+# carvel.dev/imgpkg v0.47.2
+## explicit; go 1.25.7
 carvel.dev/imgpkg/pkg/imgpkg/lockconfig
-# carvel.dev/vendir v0.45.1
-## explicit; go 1.25.6
+# carvel.dev/vendir v0.45.2
+## explicit; go 1.25.7
 carvel.dev/vendir/pkg/vendir/versions
 carvel.dev/vendir/pkg/vendir/versions/v1alpha1
 # github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,6 +35,8 @@ github.com/docker/cli/cli/config/types
 # github.com/docker/distribution v2.8.3+incompatible
 ## explicit
 github.com/docker/distribution/registry/client/auth/challenge
+# github.com/docker/docker v28.5.2+incompatible
+## explicit
 # github.com/docker/docker-credential-helpers v0.9.3
 ## explicit; go 1.21
 github.com/docker/docker-credential-helpers/client


### PR DESCRIPTION
Bumping golang to 1.25.7 to resolve the below CVEs:
```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬─────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                          Title                          │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-68121 │ CRITICAL │ fixed  │ v1.25.6           │ 1.24.13, 1.25.7, 1.26.0-rc.3 │ crypto/tls: Unexpected session resumption in crypto/tls │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-68121              │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴─────────────────────────────────────────────────────────┘
```