### PR TITLE
Bump go version and update carvel imgpkg and vendir

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -55,10 +55,10 @@ jobs:
 
         minikube start --driver=docker --wait=all --mount --mount-string "$HOME:$HOME"
 
-        # 2. RELAX THE API REQUIREMENT
+        # RELAX THE API REQUIREMENT
         # This reaches inside the minikube node, updates the daemon config, and restarts Docker
         minikube ssh "sudo mkdir -p /etc/docker && echo '{\"min-api-version\": \"1.38\"}' | sudo tee /etc/docker/daemon.json && sudo systemctl restart docker"
-        # 3. Wait a few seconds for the internal docker to come back up
+        # Wait a few seconds for the internal docker to come back up
         sleep 5
 
         eval $(minikube docker-env --shell=bash)

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -19,6 +19,8 @@ jobs:
     name: Test GH
     runs-on: ubuntu-latest
     environment: DockerHub E2E
+    env:
+      DOCKER_API_VERSION: "1.44"
     steps:
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@v1.3.0
@@ -40,6 +42,10 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         only: ytt, kapp
+    - name: Check Default Docker Version
+      run: |
+        echo "=== Docker version ==="
+        docker version || echo "docker-version not found"
     - name: Run Tests
       env:
         DOCKERHUB_USERNAME: k8slt
@@ -48,6 +54,13 @@ jobs:
         set -e -x
 
         minikube start --driver=docker --wait=all --mount --mount-string "$HOME:$HOME"
+
+        # 2. RELAX THE API REQUIREMENT
+        # This reaches inside the minikube node, updates the daemon config, and restarts Docker
+        minikube ssh "sudo mkdir -p /etc/docker && echo '{\"min-api-version\": \"1.38\"}' | sudo tee /etc/docker/daemon.json && sudo systemctl restart docker"
+        # 3. Wait a few seconds for the internal docker to come back up
+        sleep 5
+
         eval $(minikube docker-env --shell=bash)
 
         # when this workflow runs of a pull request based on a fork, secrets are unavailable

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module carvel.dev/kbld
 go 1.25.7
 
 require (
-	carvel.dev/imgpkg v0.47.1
-	carvel.dev/vendir v0.45.1
+	carvel.dev/imgpkg v0.47.2
+	carvel.dev/vendir v0.45.2
 	github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65
 	github.com/cppforlife/go-cli-ui v0.0.0-20220428182907-73db60c7611a
 	github.com/google/go-containerregistry v0.20.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/kbld
 
-go 1.25.6
+go 1.25.7
 
 require (
 	carvel.dev/imgpkg v0.47.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-carvel.dev/imgpkg v0.47.1 h1:5hJu20JeAr3HGGRCDi2ydlKVEhhF6bq0EebdB9Eql2I=
-carvel.dev/imgpkg v0.47.1/go.mod h1:f/LUtEuUHTdAeFfDcRa2MTwfXbQe6cq+kzzlQF0In6w=
-carvel.dev/vendir v0.45.1 h1:vVZjAEZz/j1HVLfm1/avlRF235skXpHFrx77GDqJMgo=
-carvel.dev/vendir v0.45.1/go.mod h1:t7/ulJsKBhyOAFyJUt3m1JyIdyvZsAh8eLGr0n1MiLk=
+carvel.dev/imgpkg v0.47.2 h1:rEqC/Saf3PHmHEhaJMcqZLjatALTPD9VmBXuUYqPaGk=
+carvel.dev/imgpkg v0.47.2/go.mod h1:3vIZkREPq+i7s8eloLEv5+t+LzzC49uv9xeh+KLADdk=
+carvel.dev/vendir v0.45.2 h1:oaOqEVgw/z4AZgCvZPgfY+JUFf3YGJSUTH2QLTyIV5A=
+carvel.dev/vendir v0.45.2/go.mod h1:R6wZyF61/mbTe4VpXBky0FiDNoCSIND+/LQvUJkkQVQ=
 github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4 h1:F4rZiMGZyC66j9VB7doVOE4tFHF1yNEihQlOuht4jmM=
 github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4/go.mod h1:4cFTBLAr/U11ykiEEQMccu4uJ1i0GS+atJmeETHCFtI=
 github.com/containerd/stargz-snapshotter/estargz v0.16.3 h1:7evrXtoh1mSbGj/pfRccTampEyKpjpOnS3CyiV1Ebr8=

--- a/hack/Dockerfile.dev
+++ b/hack/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.6
+FROM golang:1.25.7
 
 RUN apt-get update -y
 RUN apt-get install docker.io apt-transport-https ca-certificates gnupg python-is-python3 -y

--- a/hack/Dockerfile.dev
+++ b/hack/Dockerfile.dev
@@ -13,7 +13,7 @@ RUN curl -sL https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases/d
 
 RUN curl -sL https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | tar -C /usr/local/bin -xz
 
-RUN curl -sLo /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/4.2.0/bazel-4.2.0-linux-x86_64
+RUN curl -sLo /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-linux-x86_64
 RUN chmod +x /usr/local/bin/bazel
 
 RUN curl -sLo /usr/local/bin/kapp https://github.com/carvel-dev/kapp/releases/download/v0.48.0/kapp-linux-amd64

--- a/hack/test-all-locally.sh
+++ b/hack/test-all-locally.sh
@@ -34,6 +34,7 @@ done > $tempConfigFile
 docker run \
 --privileged \
 --env-file $tempConfigFile \
+-e DOCKER_API_VERSION=1.44 \
 -e KBLD_E2E_SKIP_WHEN_HTTP_REGISTRY=${KBLD_E2E_SKIP_WHEN_HTTP_REGISTRY:-true} \
 -e KBLD_E2E_DOCKERHUB_HOSTNAME=`minikube ip`:30777 \
 -v ~/.config:/root/.config \

--- a/hack/test-all-minikube-local-registry.sh
+++ b/hack/test-all-minikube-local-registry.sh
@@ -4,6 +4,7 @@ set -e -x -u
 
 export KBLD_E2E_DOCKERHUB_USERNAME=minikube-tests
 export KBLD_E2E_DOCKERHUB_HOSTNAME=${KBLD_E2E_DOCKERHUB_HOSTNAME:-`minikube ip`}
+export DOCKER_API_VERSION=1.44
 # uncomment to disable stress tests
 # export KBLD_E2E_SKIP_STRESS_TESTS=true
 

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -17,8 +17,8 @@ if [ "$(ko version)" != "0.8.0" ]; then
   exit 1
 fi
 
-if [ "$(bazel --version | grep -o '4.2.0')" != "4.2.0" ]; then
-    echo "Please install 'bazel' from https://github.com/bazelbuild/bazel/releases/tag/4.2.0"
+if [ "$(bazel --version | grep -o '6.4.0')" != "6.4.0" ]; then
+    echo "Please install 'bazel' from https://github.com/bazelbuild/bazel/releases/tag/6.4.0"
     exit 1
 fi
 

--- a/test/e2e/assets/simple-app/WORKSPACE
+++ b/test/e2e/assets/simple-app/WORKSPACE
@@ -1,11 +1,37 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "1f4e59843b61981a96835dc4ac377ad4da9f8c334ebe5e0bb3f58f80c09735f4",
-    strip_prefix = "rules_docker-0.19.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.19.0/rules_docker-v0.19.0.tar.gz"],
+    name = "io_bazel_rules_go",
+    sha256 = "91585017debb61982f7054c9688857a2ad1fd823fc3f9cb05048b0025c47d023",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
+    ],
 )
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "5d80e62a70314f39cc764c1c3eaa800c5936c9f1ea91625006227ce4d20cd086",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.42.0/bazel-gazelle-v0.42.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.42.0/bazel-gazelle-v0.42.0.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "f6dcb97e992f13bc9effd794e9bb300f06b0dadc88061f81ae68d8d5994be964",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.26.0/rules_docker-v0.26.0.tar.gz"],
+)
+
+# Initialize rules_go
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+go_rules_dependencies()
+go_register_toolchains(version = "1.23.1")
+
+# Initialize Gazelle
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+gazelle_dependencies()
 
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",

--- a/test/e2e/build_bazel_test.go
+++ b/test/e2e/build_bazel_test.go
@@ -6,6 +6,8 @@
 package e2e
 
 import (
+	"fmt"
+	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
@@ -14,7 +16,13 @@ import (
 func TestBazelBuildAndPushSuccessful(t *testing.T) {
 	env := BuildEnv(t)
 	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
-	input := env.WithRegistries(`
+
+	assetPath := "assets/simple-app"
+	secondAssetPath := "assets/simple-app-2"
+	exec.Command("cp", "-r", assetPath, secondAssetPath).Run()
+	defer exec.Command("rm", "-rf", secondAssetPath).Run()
+
+	input := env.WithRegistries(fmt.Sprintf(`
 kind: Object
 spec:
 - image: docker.io/*username*/kbld-e2e-tests-build
@@ -24,12 +32,12 @@ apiVersion: kbld.k14s.io/v1alpha1
 kind: Sources
 sources:
 - image: docker.io/*username*/kbld-e2e-tests-build
-  path: assets/simple-app
+  path: %s
   bazel:
     run:
       target: :simple-app
 - image: docker.io/*username*/kbld-e2e-tests-build2
-  path: assets/simple-app
+  path: %s
   bazel:
     run:
       target: :simple-app
@@ -39,7 +47,7 @@ kind: ImageDestinations
 destinations:
 - image: docker.io/*username*/kbld-e2e-tests-build
 - image: docker.io/*username*/kbld-e2e-tests-build2
-`)
+`, assetPath, secondAssetPath))
 
 	out, _ := kbld.RunWithOpts([]string{"-f", "-", "--images-annotation=false"}, RunOpts{
 		StdinReader: strings.NewReader(input),

--- a/test/e2e/build_bazel_test.go
+++ b/test/e2e/build_bazel_test.go
@@ -19,7 +19,9 @@ func TestBazelBuildAndPushSuccessful(t *testing.T) {
 
 	assetPath := "assets/simple-app"
 	secondAssetPath := "assets/simple-app-2"
-	exec.Command("cp", "-r", assetPath, secondAssetPath).Run()
+	if err := exec.Command("cp", "-r", assetPath, secondAssetPath).Run(); err != nil {
+		t.Fatalf("failed to copy %s to %s: %v", assetPath, secondAssetPath, err)
+	}
 	defer exec.Command("rm", "-rf", secondAssetPath).Run()
 
 	input := env.WithRegistries(fmt.Sprintf(`

--- a/test/e2e/build_bazel_test.go
+++ b/test/e2e/build_bazel_test.go
@@ -22,7 +22,11 @@ func TestBazelBuildAndPushSuccessful(t *testing.T) {
 	if err := exec.Command("cp", "-r", assetPath, secondAssetPath).Run(); err != nil {
 		t.Fatalf("failed to copy %s to %s: %v", assetPath, secondAssetPath, err)
 	}
-	defer exec.Command("rm", "-rf", secondAssetPath).Run()
+	defer func() {
+		if err := exec.Command("rm", "-rf", secondAssetPath).Run(); err != nil {
+			t.Logf("failed to remove %s: %v", secondAssetPath, err)
+		}
+	}()
 
 	input := env.WithRegistries(fmt.Sprintf(`
 kind: Object

--- a/test/e2e/build_pack_test.go
+++ b/test/e2e/build_pack_test.go
@@ -6,6 +6,8 @@
 package e2e
 
 import (
+	"fmt"
+	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
@@ -15,7 +17,13 @@ func TestPackBuildAndPushSuccessful(t *testing.T) {
 	env := BuildEnv(t)
 	kbld := Kbld{t, env.KbldBinaryPath, Logger{}}
 
-	input := env.WithRegistries(`
+	// Copy asset to avoid parallel build interference
+	assetPath := "assets/simple-app"
+	secondAssetPath := "assets/simple-app-2"
+	exec.Command("cp", "-r", assetPath, secondAssetPath).Run()
+	defer exec.Command("rm", "-rf", secondAssetPath).Run()
+
+	input := env.WithRegistries(fmt.Sprintf(`
 kind: Object
 spec:
 - image: docker.io/*username*/kbld-e2e-tests-build
@@ -25,12 +33,12 @@ apiVersion: kbld.k14s.io/v1alpha1
 kind: Sources
 sources:
 - image: docker.io/*username*/kbld-e2e-tests-build
-  path: assets/simple-app
+  path: %s
   pack: &pack
     build:
       builder: index.docker.io/cloudfoundry/cnb@sha256:83270cf59e8944be0c544e45fd45a5a1f4526d7936d488d2de8937730341618d
 - image: docker.io/*username*/kbld-e2e-tests-build2
-  path: assets/simple-app
+  path: %s
   pack: &pack
     build:
       builder: index.docker.io/cloudfoundry/cnb@sha256:83270cf59e8944be0c544e45fd45a5a1f4526d7936d488d2de8937730341618d
@@ -40,7 +48,7 @@ kind: ImageDestinations
 destinations:
 - image: docker.io/*username*/kbld-e2e-tests-build
 - image: docker.io/*username*/kbld-e2e-tests-build2
-`)
+`, assetPath, secondAssetPath))
 
 	out, _ := kbld.RunWithOpts([]string{"-f", "-", "--images-annotation=false"}, RunOpts{
 		StdinReader: strings.NewReader(input),

--- a/test/e2e/build_pack_test.go
+++ b/test/e2e/build_pack_test.go
@@ -20,8 +20,15 @@ func TestPackBuildAndPushSuccessful(t *testing.T) {
 	// Copy asset to avoid parallel build interference
 	assetPath := "assets/simple-app"
 	secondAssetPath := "assets/simple-app-2"
-	exec.Command("cp", "-r", assetPath, secondAssetPath).Run()
-	defer exec.Command("rm", "-rf", secondAssetPath).Run()
+	copyCmd := exec.Command("cp", "-r", assetPath, secondAssetPath)
+	if err := copyCmd.Run(); err != nil {
+		t.Fatalf("failed to copy asset from %s to %s: %v", assetPath, secondAssetPath, err)
+	}
+	defer func() {
+		if err := exec.Command("rm", "-rf", secondAssetPath).Run(); err != nil {
+			t.Logf("failed to remove temporary asset path %s: %v", secondAssetPath, err)
+		}
+	}()
 
 	input := env.WithRegistries(fmt.Sprintf(`
 kind: Object

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,8 @@
-# carvel.dev/imgpkg v0.47.1
-## explicit; go 1.25.6
+# carvel.dev/imgpkg v0.47.2
+## explicit; go 1.25.7
 carvel.dev/imgpkg/pkg/imgpkg/lockconfig
-# carvel.dev/vendir v0.45.1
-## explicit; go 1.25.6
+# carvel.dev/vendir v0.45.2
+## explicit; go 1.25.7
 carvel.dev/vendir/pkg/vendir/versions
 carvel.dev/vendir/pkg/vendir/versions/v1alpha1
 # github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4


### PR DESCRIPTION
This PR bumps the Docker API version requirements and updates associated dependencies to support the newer Docker engine (v28.0.4), which requires a minimum Docker API version of 1.44.0.

Changes:

- Bump Go to 1.25.7 and update carvel.dev/imgpkg to v0.47.2 and carvel.dev/vendir to v0.45.2
- Bump Bazel from 4.2.0 to 6.4.0 and update its associated rules in the WORKSPACE file
- Add DOCKER_API_VERSION=1.44 environment variable to test scripts and CI workflow, and fix parallel build interference in pack/bazel tests