### PR TITLE
Bump Carvel Dependencies and Golang 1.25.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module carvel.dev/kbld
 
-go 1.25.6
+go 1.25.7
 
 require (
-	carvel.dev/imgpkg v0.47.1
-	carvel.dev/vendir v0.45.1
+	carvel.dev/imgpkg v0.47.2
+	carvel.dev/vendir v0.45.2
 	github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65
 	github.com/cppforlife/go-cli-ui v0.0.0-20220428182907-73db60c7611a
 	github.com/google/go-containerregistry v0.20.6

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-carvel.dev/imgpkg v0.47.1 h1:5hJu20JeAr3HGGRCDi2ydlKVEhhF6bq0EebdB9Eql2I=
-carvel.dev/imgpkg v0.47.1/go.mod h1:f/LUtEuUHTdAeFfDcRa2MTwfXbQe6cq+kzzlQF0In6w=
-carvel.dev/vendir v0.45.1 h1:vVZjAEZz/j1HVLfm1/avlRF235skXpHFrx77GDqJMgo=
-carvel.dev/vendir v0.45.1/go.mod h1:t7/ulJsKBhyOAFyJUt3m1JyIdyvZsAh8eLGr0n1MiLk=
+carvel.dev/imgpkg v0.47.2 h1:rEqC/Saf3PHmHEhaJMcqZLjatALTPD9VmBXuUYqPaGk=
+carvel.dev/imgpkg v0.47.2/go.mod h1:3vIZkREPq+i7s8eloLEv5+t+LzzC49uv9xeh+KLADdk=
+carvel.dev/vendir v0.45.2 h1:oaOqEVgw/z4AZgCvZPgfY+JUFf3YGJSUTH2QLTyIV5A=
+carvel.dev/vendir v0.45.2/go.mod h1:R6wZyF61/mbTe4VpXBky0FiDNoCSIND+/LQvUJkkQVQ=
 github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4 h1:F4rZiMGZyC66j9VB7doVOE4tFHF1yNEihQlOuht4jmM=
 github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4/go.mod h1:4cFTBLAr/U11ykiEEQMccu4uJ1i0GS+atJmeETHCFtI=
 github.com/containerd/stargz-snapshotter/estargz v0.16.3 h1:7evrXtoh1mSbGj/pfRccTampEyKpjpOnS3CyiV1Ebr8=

--- a/hack/Dockerfile.dev
+++ b/hack/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.6
+FROM golang:1.25.7
 
 RUN apt-get update -y
 RUN apt-get install docker.io apt-transport-https ca-certificates gnupg python-is-python3 -y

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,8 @@
-# carvel.dev/imgpkg v0.47.1
-## explicit; go 1.25.6
+# carvel.dev/imgpkg v0.47.2
+## explicit; go 1.25.7
 carvel.dev/imgpkg/pkg/imgpkg/lockconfig
-# carvel.dev/vendir v0.45.1
-## explicit; go 1.25.6
+# carvel.dev/vendir v0.45.2
+## explicit; go 1.25.7
 carvel.dev/vendir/pkg/vendir/versions
 carvel.dev/vendir/pkg/vendir/versions/v1alpha1
 # github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4


### PR DESCRIPTION
Bumping golang to 1.25.7 to resolve the below CVEs:
```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬─────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                          Title                          │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-68121 │ CRITICAL │ fixed  │ v1.25.6           │ 1.24.13, 1.25.7, 1.26.0-rc.3 │ crypto/tls: Unexpected session resumption in crypto/tls │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-68121              │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴─────────────────────────────────────────────────────────┘
```