### PR TITLE
Bump vendir to v0.45.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	carvel.dev/imgpkg v0.47.2
-	carvel.dev/vendir v0.45.2
+	carvel.dev/vendir v0.45.3
 	github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65
 	github.com/cppforlife/go-cli-ui v0.0.0-20220428182907-73db60c7611a
 	github.com/google/go-containerregistry v0.20.6
@@ -18,7 +18,7 @@ require (
 )
 
 require (
-	github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4 // indirect
+	github.com/carvel-dev/semver/v4 v4.0.1-0.20260413160702-f136b2e8bf02 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 carvel.dev/imgpkg v0.47.2 h1:rEqC/Saf3PHmHEhaJMcqZLjatALTPD9VmBXuUYqPaGk=
 carvel.dev/imgpkg v0.47.2/go.mod h1:3vIZkREPq+i7s8eloLEv5+t+LzzC49uv9xeh+KLADdk=
-carvel.dev/vendir v0.45.2 h1:oaOqEVgw/z4AZgCvZPgfY+JUFf3YGJSUTH2QLTyIV5A=
-carvel.dev/vendir v0.45.2/go.mod h1:R6wZyF61/mbTe4VpXBky0FiDNoCSIND+/LQvUJkkQVQ=
-github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4 h1:F4rZiMGZyC66j9VB7doVOE4tFHF1yNEihQlOuht4jmM=
-github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4/go.mod h1:4cFTBLAr/U11ykiEEQMccu4uJ1i0GS+atJmeETHCFtI=
+carvel.dev/vendir v0.45.3 h1:crIwlGpsdvABTiUM71IbAaanavyET7+FhnI8hrd3x3U=
+carvel.dev/vendir v0.45.3/go.mod h1:ulOigkUjXfCYidNbHqNAtEf0MFnuwG4jhoEqG2giOnU=
+github.com/carvel-dev/semver/v4 v4.0.1-0.20260413160702-f136b2e8bf02 h1:LP+GFDwgIBQFld1EhQt3UaN1typu03sqU3eWCKM5Isk=
+github.com/carvel-dev/semver/v4 v4.0.1-0.20260413160702-f136b2e8bf02/go.mod h1:4cFTBLAr/U11ykiEEQMccu4uJ1i0GS+atJmeETHCFtI=
 github.com/containerd/stargz-snapshotter/estargz v0.16.3 h1:7evrXtoh1mSbGj/pfRccTampEyKpjpOnS3CyiV1Ebr8=
 github.com/containerd/stargz-snapshotter/estargz v0.16.3/go.mod h1:uyr4BfYfOj3G9WBVE8cOlQmXAbPN9VEQpBBeJIuOipU=
 github.com/cppforlife/cobrautil v0.0.0-20221021151949-d60711905d65 h1:+3J1K6yQFRPKDEl5Py68c1q0FjaCkeMcB1nb7uzmpSw=

--- a/vendor/github.com/carvel-dev/semver/v4/semver.go
+++ b/vendor/github.com/carvel-dev/semver/v4/semver.go
@@ -3,6 +3,7 @@ package semver
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -18,6 +19,8 @@ const (
 	prereleaseType versionExtType = "PreRelease"
 	buildmetaType                 = "BuildMeta"
 )
+
+var chunkRegexp = regexp.MustCompile(`(\d+|\D+)`)
 
 // SpecVersion is the latest fully supported spec version of semver
 var SpecVersion = Version{
@@ -193,10 +196,10 @@ func (v Version) Validate() error {
 
 	for _, build := range v.Build {
 		if len(build.VersionStr) == 0 {
-			return fmt.Errorf("Build meta data can not be empty %q", build)
+			return fmt.Errorf("Build meta data can not be empty %q", build.VersionStr)
 		}
 		if !containsOnly(build.VersionStr, alphanum) {
-			return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
+			return fmt.Errorf("Invalid character(s) found in build meta data %q", build.VersionStr)
 		}
 	}
 
@@ -285,9 +288,7 @@ func Parse(s string) (Version, error) {
 		return Version{}, err
 	}
 
-	v := Version{}
-	v.Major = major
-	v.Minor = minor
+	v := Version{Major: major, Minor: minor}
 
 	var build, prerelease []string
 	patchStr := parts[2]
@@ -368,10 +369,8 @@ func (ve BuildMeta) Compare(o BuildMeta) int {
 	for ; i < len(ve) && i < len(o); i++ {
 		if comp := ve[i].Compare(o[i]); comp == 0 {
 			continue
-		} else if comp == 1 {
-			return 1
 		} else {
-			return -1
+			return comp
 		}
 	}
 
@@ -399,10 +398,8 @@ func (ve PRVersion) Compare(o PRVersion) int {
 	for ; i < len(ve) && i < len(o); i++ {
 		if comp := ve[i].Compare(o[i]); comp == 0 {
 			continue
-		} else if comp == 1 {
-			return 1
 		} else {
-			return -1
+			return comp
 		}
 	}
 
@@ -431,7 +428,7 @@ func newVersionExtension(s string, extType versionExtType, additionalValidations
 
 		// Might never be hit, but just in case
 		if err != nil {
-			return versionExtension{}, err
+			return versionExtension{}, fmt.Errorf("Invalid numeric %s %q: %s", extType, s, err)
 		}
 		v.VersionNum = num
 		v.IsNum = true
@@ -450,7 +447,7 @@ func newVersionExtension(s string, extType versionExtType, additionalValidations
 	return v, nil
 }
 
-// IsNumeric checks if this extension is numeric is numeric
+// IsNumeric checks if this extension is numeric
 func (v versionExtension) IsNumeric() bool {
 	return v.IsNum
 }
@@ -460,27 +457,57 @@ func (v versionExtension) IsNumeric() bool {
 // 0 == v is equal to o
 // 1 == v is greater than o
 func (v versionExtension) Compare(o versionExtension) int {
-	if v.IsNum && !o.IsNum {
-		return -1
-	} else if !v.IsNum && o.IsNum {
-		return 1
-	} else if v.IsNum && o.IsNum {
+	// 1. Numeric vs Numeric: Standard comparison
+	if v.IsNum && o.IsNum {
 		if v.VersionNum == o.VersionNum {
 			return 0
-		} else if v.VersionNum > o.VersionNum {
-			return 1
-		} else {
-			return -1
 		}
-	} else { // both are Alphas
-		if v.VersionStr == o.VersionStr {
-			return 0
-		} else if v.VersionStr > o.VersionStr {
+		if v.VersionNum > o.VersionNum {
 			return 1
-		} else {
-			return -1
 		}
+		return -1
 	}
+
+	// 2. Handle Numeric vs Alphanumeric
+	// Identify segments containing pre-release identifiers (rc, alpha, beta).
+	isPreReleaseLabel := func(s string) bool {
+		lowerStr := strings.ToLower(s)
+		if !strings.Contains(lowerStr, "-") {
+			return false
+		}
+		// Only flag as pre-release if it contains these specific markers
+		preReleaseMarkers := []string{"alpha", "beta", "rc", "pre", "dev"}
+		for _, marker := range preReleaseMarkers {
+			if strings.Contains(lowerStr, marker) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if v.IsNum && !o.IsNum {
+		if isPreReleaseLabel(o.VersionStr) {
+			return 1 // Number wins against an RC/Alpha/Beta string
+		}
+		return -1 // Standard SemVer: Number < String
+	}
+	if !v.IsNum && o.IsNum {
+		if isPreReleaseLabel(v.VersionStr) {
+			return -1 // RC/Alpha/Beta string loses against a Number
+		}
+		return 1 // Standard SemVer: String > Number
+	}
+
+	// 3. Both are Alphanumeric
+	if v.VersionStr == o.VersionStr {
+		return 0
+	}
+
+	// Natural sort fallback for generic segments (e.g. "9-fips" vs "10-fips")
+	if naturalLess(v.VersionStr, o.VersionStr) {
+		return -1
+	}
+	return 1
 }
 
 func (v versionExtension) String() string {
@@ -507,8 +534,7 @@ func validatePRLeading0s(ext versionExtension) error {
 	return nil
 }
 
-// FinalizeVersion returns the major, minor and patch number only and discards
-// prerelease and build number.
+// FinalizeVersion returns the major, minor and patch number only.
 func FinalizeVersion(s string) (string, error) {
 	v, err := Parse(s)
 	if err != nil {
@@ -516,7 +542,34 @@ func FinalizeVersion(s string) (string, error) {
 	}
 	v.Pre = nil
 	v.Build = nil
+	return v.String(), nil
+}
 
-	finalVer := v.String()
-	return finalVer, nil
+func naturalLess(s1, s2 string) bool {
+	chunks1 := chunkRegexp.FindAllString(s1, -1)
+	chunks2 := chunkRegexp.FindAllString(s2, -1)
+
+	n := len(chunks1)
+	if len(chunks2) < n {
+		n = len(chunks2)
+	}
+
+	for i := 0; i < n; i++ {
+		c1, c2 := chunks1[i], chunks2[i]
+		if c1 == c2 {
+			continue
+		}
+
+		n1, err1 := strconv.ParseUint(c1, 10, 64)
+		n2, err2 := strconv.ParseUint(c2, 10, 64)
+
+		if err1 == nil && err2 == nil {
+			if n1 != n2 {
+				return n1 < n2
+			}
+			continue
+		}
+		return c1 < c2
+	}
+	return len(chunks1) < len(chunks2)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,11 +1,11 @@
 # carvel.dev/imgpkg v0.47.2
 ## explicit; go 1.25.7
 carvel.dev/imgpkg/pkg/imgpkg/lockconfig
-# carvel.dev/vendir v0.45.2
+# carvel.dev/vendir v0.45.3
 ## explicit; go 1.25.7
 carvel.dev/vendir/pkg/vendir/versions
 carvel.dev/vendir/pkg/vendir/versions/v1alpha1
-# github.com/carvel-dev/semver/v4 v4.0.1-0.20240402203627-beb83fbf25e4
+# github.com/carvel-dev/semver/v4 v4.0.1-0.20260413160702-f136b2e8bf02
 ## explicit; go 1.14
 github.com/carvel-dev/semver/v4
 # github.com/containerd/stargz-snapshotter/estargz v0.16.3


### PR DESCRIPTION
Bumps the carvel.dev/vendir dependency to v0.45.3 (and updates the vendored module set accordingly, including an updated github.com/carvel-dev/semver/v4 snapshot).

**Changes:**

Update carvel.dev/vendir from v0.45.2 → v0.45.3 in go.mod / go.sum.
Update vendored module metadata (vendor/modules.txt).
Refresh vendored github.com/carvel-dev/semver/v4 implementation as pulled in by the bump.
